### PR TITLE
feat(daemon): stamp ACP command-identity digest on sessions

### DIFF
--- a/packages/daemon/src/lib/acp/acp-command.ts
+++ b/packages/daemon/src/lib/acp/acp-command.ts
@@ -3,7 +3,6 @@ import { getAcpCommandIdentity } from '@hyperneo/shared/acp';
 
 export { getAcpCommandIdentity, parseAcpCommand } from '@hyperneo/shared/acp';
 
-/* @public - consumed by ACP provider sync in a later stack PR */
 export function getAcpCommandIdentityDigest(commandLine: string): string {
   return createHash('sha256').update(getAcpCommandIdentity(commandLine)).digest('hex');
 }

--- a/packages/daemon/src/lib/acp/acp-query-runner.ts
+++ b/packages/daemon/src/lib/acp/acp-query-runner.ts
@@ -34,7 +34,7 @@ import {
   resolveSpaceMcpSessionPolicy,
 } from '../space/runtime/space-mcp-session-policy';
 import { AcpClient, type AcpClientOptions } from './acp-client';
-import { parseAcpCommand } from './acp-command';
+import { getAcpCommandIdentityDigest, parseAcpCommand } from './acp-command';
 import { AcpQueryAdapter } from './acp-query-adapter';
 import { AcpMcpProxyBridge, shouldProxy } from './mcp-proxy-bridge';
 
@@ -456,6 +456,27 @@ export class AcpQueryRunner {
         throw new Error('Set HYPERNEO_ACP_COMMAND to enable ACP agents.');
       }
       const { command, args } = parseAcpCommand(acpCommand);
+      const commandIdentity = getAcpCommandIdentityDigest(acpCommand);
+      const storedIdentity = session.metadata?.acpCommandIdentity;
+      if (session.acpSessionId && storedIdentity !== undefined && storedIdentity !== commandIdentity) {
+        session.acpSessionId = undefined;
+        session.metadata = {
+          ...session.metadata,
+          acpCommandIdentity: commandIdentity,
+          acpInstructionsSent: undefined,
+          acpContextUsageEstimate: undefined,
+        };
+        this.ctx.db.updateSession(session.id, {
+          acpSessionId: undefined,
+          metadata: session.metadata,
+        });
+      } else if (storedIdentity !== commandIdentity) {
+        session.metadata = {
+          ...session.metadata,
+          acpCommandIdentity: commandIdentity,
+        };
+        this.ctx.db.updateSession(session.id, { metadata: session.metadata });
+      }
       const preCleanupAuth = {
         ANTHROPIC_AUTH_TOKEN: process.env.ANTHROPIC_AUTH_TOKEN,
         CLAUDE_CODE_OAUTH_TOKEN: process.env.CLAUDE_CODE_OAUTH_TOKEN,

--- a/packages/daemon/src/lib/acp/acp-query-runner.ts
+++ b/packages/daemon/src/lib/acp/acp-query-runner.ts
@@ -352,6 +352,8 @@ function acpInstructionBlocks(queryOptions: Options): AcpContentBlock[] {
 type AcpClientFactory = (options: AcpClientOptions) => AcpClient;
 
 export class AcpQueryRunner {
+  private pendingAcpIdentityMetadata = false;
+
   private _lastConsumedUserMessage: {
     uuid: string;
     content: string | MessageContent[];
@@ -458,28 +460,20 @@ export class AcpQueryRunner {
       const { command, args } = parseAcpCommand(acpCommand);
       const commandIdentity = getAcpCommandIdentityDigest(acpCommand);
       const storedIdentity = session.metadata?.acpCommandIdentity;
-      if (
-        session.acpSessionId &&
-        storedIdentity !== undefined &&
-        storedIdentity !== commandIdentity
-      ) {
-        session.acpSessionId = undefined;
-        session.metadata = {
-          ...session.metadata,
-          acpCommandIdentity: commandIdentity,
-          acpInstructionsSent: undefined,
-          acpContextUsageEstimate: undefined,
-        };
-        this.ctx.db.updateSession(session.id, {
-          acpSessionId: undefined,
-          metadata: session.metadata,
-        });
-      } else if (storedIdentity !== commandIdentity) {
+      if (storedIdentity !== commandIdentity) {
+        if (session.acpSessionId && storedIdentity !== undefined) {
+          session.acpSessionId = undefined;
+          session.metadata = {
+            ...session.metadata,
+            acpInstructionsSent: undefined,
+            acpContextUsageEstimate: undefined,
+          };
+        }
         session.metadata = {
           ...session.metadata,
           acpCommandIdentity: commandIdentity,
         };
-        this.ctx.db.updateSession(session.id, { metadata: session.metadata });
+        this.pendingAcpIdentityMetadata = true;
       }
       const preCleanupAuth = {
         ANTHROPIC_AUTH_TOKEN: process.env.ANTHROPIC_AUTH_TOKEN,
@@ -1070,8 +1064,13 @@ export class AcpQueryRunner {
 
   private persistAcpSessionId(acpSessionId: string | undefined): void {
     const { session, db } = this.ctx;
-    if (session.acpSessionId === acpSessionId) return;
+    if (session.acpSessionId === acpSessionId && !this.pendingAcpIdentityMetadata) return;
     session.acpSessionId = acpSessionId;
+    if (this.pendingAcpIdentityMetadata) {
+      this.pendingAcpIdentityMetadata = false;
+      db.updateSession(session.id, { acpSessionId, metadata: session.metadata });
+      return;
+    }
     db.updateSession(session.id, { acpSessionId });
   }
 

--- a/packages/daemon/src/lib/acp/acp-query-runner.ts
+++ b/packages/daemon/src/lib/acp/acp-query-runner.ts
@@ -458,7 +458,11 @@ export class AcpQueryRunner {
       const { command, args } = parseAcpCommand(acpCommand);
       const commandIdentity = getAcpCommandIdentityDigest(acpCommand);
       const storedIdentity = session.metadata?.acpCommandIdentity;
-      if (session.acpSessionId && storedIdentity !== undefined && storedIdentity !== commandIdentity) {
+      if (
+        session.acpSessionId &&
+        storedIdentity !== undefined &&
+        storedIdentity !== commandIdentity
+      ) {
         session.acpSessionId = undefined;
         session.metadata = {
           ...session.metadata,

--- a/packages/daemon/tests/unit/lib/acp/acp-query-runner.test.ts
+++ b/packages/daemon/tests/unit/lib/acp/acp-query-runner.test.ts
@@ -11,6 +11,7 @@ import type { QueryOptionsBuilder } from '../../../../src/lib/agent/query-option
 import type { AskUserQuestionHandler } from '../../../../src/lib/agent/ask-user-question-handler';
 import type { QueryRunnerContext } from '../../../../src/lib/agent/query-runner';
 import type { AcpClient, AcpClientOptions } from '../../../../src/lib/acp/acp-client';
+import { getAcpCommandIdentityDigest } from '../../../../src/lib/acp/acp-command';
 import {
   AcpQueryRunner,
   convertMcpServersForAcp,
@@ -842,6 +843,93 @@ describe('AcpQueryRunner', () => {
     expect(ctx.db.updateSession).toHaveBeenCalledWith('session-1', {
       acpSessionId: 'acp-session-1',
     });
+  });
+
+  test('creates a new ACP session when the persisted command identity changes', async () => {
+    const client = createMockClient();
+    client.canLoadSession.mockImplementation(() => true);
+    const { runner, ctx } = createRunnerFixture({
+      client,
+      session: {
+        acpSessionId: 'persisted-acp-session',
+        metadata: {
+          acpCommandIdentity: getAcpCommandIdentityDigest('other-acp --stdio'),
+          acpInstructionsSent: true,
+          acpContextUsageEstimate: 12000,
+        },
+      } as Partial<Session>,
+      queryOptions: {
+        cwd: '/tmp/acp-session',
+        mcpServers: {},
+        systemPrompt: { type: 'preset', preset: 'none', append: 'Follow current rules.' },
+      },
+    });
+
+    await runner.start();
+    await ctx.queryPromise;
+
+    expect(client.loadSession).not.toHaveBeenCalled();
+    expect(client.resumeSession).not.toHaveBeenCalled();
+    expect(client.createSession).toHaveBeenCalledWith('/tmp/acp-session', []);
+    expect(ctx.db.updateSession).toHaveBeenCalledWith('session-1', {
+      acpSessionId: undefined,
+      metadata: expect.objectContaining({
+        acpCommandIdentity: getAcpCommandIdentityDigest('mock-acp --stdio'),
+        acpContextUsageEstimate: undefined,
+      }),
+    });
+    expect(ctx.session.metadata.acpInstructionsSent).toBe(true);
+    expect(client.sendPrompt.mock.calls[0][0]).toEqual([
+      {
+        type: 'text',
+        text: 'HyperNeo session instructions:\n\nFollow current rules.',
+      },
+      { type: 'text', text: 'hello' },
+    ]);
+  });
+
+  test('preserves an existing session whose command identity matches', async () => {
+    const client = createMockClient();
+    client.canLoadSession.mockImplementation(() => true);
+    client.loadSession.mockImplementation(async (sessionId: string) => ({
+      sessionId,
+      configOptions: [],
+    }));
+    const { runner, ctx } = createRunnerFixture({
+      client,
+      session: {
+        acpSessionId: 'persisted-acp-session',
+        metadata: {
+          messageCount: 2,
+          acpCommandIdentity: getAcpCommandIdentityDigest('mock-acp --stdio'),
+        },
+      } as Partial<Session>,
+    });
+
+    await runner.start();
+    await ctx.queryPromise;
+
+    expect(client.loadSession).toHaveBeenCalledWith(
+      'persisted-acp-session',
+      '/tmp/acp-session',
+      []
+    );
+    expect(client.createSession).not.toHaveBeenCalled();
+    expect(ctx.session.metadata.acpCommandIdentity).toBe(
+      getAcpCommandIdentityDigest('mock-acp --stdio')
+    );
+  });
+
+  test('persists only a digest of the ACP command identity', async () => {
+    process.env.HYPERNEO_ACP_COMMAND = 'devin acp --token topsecret';
+    const { runner, ctx } = createRunnerFixture();
+
+    await runner.start();
+    await ctx.queryPromise;
+
+    const identity = ctx.session.metadata.acpCommandIdentity as string;
+    expect(identity).toBe(getAcpCommandIdentityDigest('devin acp --token topsecret'));
+    expect(identity).not.toContain('topsecret');
   });
 
   test('loads an existing ACP session instead of creating a new one', async () => {

--- a/packages/daemon/tests/unit/lib/acp/acp-query-runner.test.ts
+++ b/packages/daemon/tests/unit/lib/acp/acp-query-runner.test.ts
@@ -842,6 +842,9 @@ describe('AcpQueryRunner', () => {
     expect(ctx.session.acpSessionId).toBe('acp-session-1');
     expect(ctx.db.updateSession).toHaveBeenCalledWith('session-1', {
       acpSessionId: 'acp-session-1',
+      metadata: expect.objectContaining({
+        acpCommandIdentity: getAcpCommandIdentityDigest('mock-acp --stdio'),
+      }),
     });
   });
 
@@ -872,12 +875,15 @@ describe('AcpQueryRunner', () => {
     expect(client.resumeSession).not.toHaveBeenCalled();
     expect(client.createSession).toHaveBeenCalledWith('/tmp/acp-session', []);
     expect(ctx.db.updateSession).toHaveBeenCalledWith('session-1', {
-      acpSessionId: undefined,
+      acpSessionId: 'acp-session-1',
       metadata: expect.objectContaining({
         acpCommandIdentity: getAcpCommandIdentityDigest('mock-acp --stdio'),
         acpContextUsageEstimate: undefined,
       }),
     });
+    for (const call of ctx.db.updateSession.mock.calls) {
+      expect(call[1]).not.toMatchObject({ acpSessionId: undefined });
+    }
     expect(ctx.session.metadata.acpInstructionsSent).toBe(true);
     expect(client.sendPrompt.mock.calls[0][0]).toEqual([
       {
@@ -915,6 +921,34 @@ describe('AcpQueryRunner', () => {
       []
     );
     expect(client.createSession).not.toHaveBeenCalled();
+    expect(ctx.session.metadata.acpCommandIdentity).toBe(
+      getAcpCommandIdentityDigest('mock-acp --stdio')
+    );
+  });
+
+  test('keeps the old ACP session id when the replacement command fails to start', async () => {
+    const client = createMockClient();
+    client.initialize.mockImplementation(async () => {
+      throw new Error('replacement agent unavailable');
+    });
+    const { runner, ctx } = createRunnerFixture({
+      client,
+      session: {
+        acpSessionId: 'persisted-acp-session',
+        metadata: {
+          acpCommandIdentity: getAcpCommandIdentityDigest('other-acp --stdio'),
+        },
+      } as Partial<Session>,
+    });
+
+    await runner.start();
+    await ctx.queryPromise;
+
+    for (const call of ctx.db.updateSession.mock.calls) {
+      expect(call[1]).not.toMatchObject({ acpSessionId: undefined });
+      expect(call[1]).not.toHaveProperty('metadata');
+    }
+    expect(ctx.session.acpSessionId).toBe(undefined);
     expect(ctx.session.metadata.acpCommandIdentity).toBe(
       getAcpCommandIdentityDigest('mock-acp --stdio')
     );
@@ -1000,6 +1034,9 @@ describe('AcpQueryRunner', () => {
     expect(ctx.session.acpSessionId).toBe('resumed-acp-session');
     expect(ctx.db.updateSession).toHaveBeenCalledWith('session-1', {
       acpSessionId: 'resumed-acp-session',
+      metadata: expect.objectContaining({
+        acpCommandIdentity: getAcpCommandIdentityDigest('mock-acp --stdio'),
+      }),
     });
   });
 

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -317,6 +317,7 @@ export interface SessionMetadata {
   costBaseline?: number;
   refusalRewindTargetUuid?: string | null;
   acpInstructionsSent?: boolean;
+  acpCommandIdentity?: string;
   pastSdkSessionIds?: string[];
   acpContextUsageEstimate?: number;
   worktreeChoice?: {


### PR DESCRIPTION
Extracted from #2711 (ACP split 8/10).

## What this adds

- `SessionMetadata.acpCommandIdentity` (shared types): stores a digest of the ACP launch command per session.
- `AcpQueryRunner` stamps the digest at query start; when it differs from the persisted one **and** an ACP session id exists, the runner drops the persisted session/instructions/context estimate and starts a fresh conversation — switching the agent command (`devin acp` → `claude-agent-acp …`) no longer resumes a session created by a different agent. When there is no persisted session, it just stamps.
- Only the digest is persisted — the raw command line never reaches session metadata.
- `getAcpCommandIdentityDigest` loses its `@public` knip marker: the query runner is its consumer now.
- 3 tests: identity change → fresh session (instructions re-sent), identity match → session preserved, digest-only persistence.

## Notes

- Uses the existing digest as-is (hash of the parsed command identity). The redaction-aware digest variant is deliberately parked with the rest of the security-hardening slices (#2782, PR #2781); if revived, stamping logic here is agnostic to which digest it calls.
- No other query-runner behavior from #2711 is pulled in by this slice.

## Verification

- `bun test tests/unit/lib/acp/acp-query-runner.test.ts` — 47/47
- knip, `tsc --build --noEmit`, oxlint, biome — clean
- Full `tests/unit/lib/acp/` failure set identical to the clean-dev sandbox baseline (pre-existing AcpClient/mock-server environment noise, none in files this PR touches)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/lsm/hyperneo/pull/2783" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->