### PR TITLE
feat(daemon): wire ACP host callbacks in bypass mode

### DIFF
--- a/packages/daemon/src/lib/acp/acp-query-runner.ts
+++ b/packages/daemon/src/lib/acp/acp-query-runner.ts
@@ -1,6 +1,6 @@
 import type { UUID } from 'crypto';
 import { fileURLToPath } from 'node:url';
-import type { CanUseTool, Options } from '@anthropic-ai/claude-agent-sdk';
+import type { Options } from '@anthropic-ai/claude-agent-sdk';
 import {
   generateUUID,
   THINKING_LEVEL_TOKENS,
@@ -10,9 +10,18 @@ import {
 import type {
   AcpConfigOption,
   AcpContentBlock,
+  AcpFsReadParams,
+  AcpFsReadResult,
+  AcpFsWriteParams,
+  AcpFsWriteResult,
   AcpMcpServerConfig,
   AcpPermissionRequest,
   AcpPermissionResponseResult,
+  AcpTerminalCreateParams,
+  AcpTerminalKillParams,
+  AcpTerminalOutputParams,
+  AcpTerminalReleaseParams,
+  AcpTerminalWaitForExitParams,
 } from '@hyperneo/shared/acp';
 import type { McpServerConfig, SDKMessage, SDKUserMessage } from '@hyperneo/shared/sdk';
 import { ErrorCategory } from '../error-manager';
@@ -33,13 +42,18 @@ import {
   missingMcpServers,
   resolveSpaceMcpSessionPolicy,
 } from '../space/runtime/space-mcp-session-policy';
+import { isAbsolute, relative, resolve, sep } from 'node:path';
 import { AcpClient, type AcpClientOptions } from './acp-client';
-import { getAcpCommandIdentityDigest, parseAcpCommand } from './acp-command';
+import { buildAcpSafeEnv, getAcpCommandIdentityDigest, parseAcpCommand } from './acp-command';
+import { getAcpProcessTreeOwner } from './acp-process-tree';
 import { AcpQueryAdapter } from './acp-query-adapter';
+import { isSafeFsSupported, readFileWithinWorkspace, writeFileWithinWorkspace } from './acp-safe-fs';
+import { AcpTerminalManager } from './acp-terminal-manager';
 import { AcpMcpProxyBridge, shouldProxy } from './mcp-proxy-bridge';
 
 const DEFAULT_STARTUP_TIMEOUT_MS = 15000;
 const RETRY_EXIT_TIMEOUT_MS = 5000;
+const MAX_FS_READ_BYTES = 4 * 1024 * 1024;
 
 function getStartupTimeoutMs(): number {
   const raw = process.env.HYPERNEO_SDK_STARTUP_TIMEOUT_MS;
@@ -251,69 +265,36 @@ export function convertMcpServersForAcp(
   });
 }
 
-function getAcpWorkspacePath(session: Session, queryOptions: Options): string {
-  return (
-    queryOptions.cwd ?? session.worktree?.worktreePath ?? session.workspacePath ?? process.cwd()
-  );
+function getAcpWorkspacePath(session: Session, queryOptions: Options): string | undefined {
+  return queryOptions.cwd ?? session.worktree?.worktreePath ?? session.workspacePath ?? undefined;
 }
 
-function acpPermissionQuestion(params: AcpPermissionRequest): string {
-  return params.toolCall.title
-    ? `Allow ${params.toolCall.title}?`
-    : `Allow ACP tool ${params.toolCall.toolCallId}?`;
-}
-
-function acpPermissionQuestionInput(params: AcpPermissionRequest): Record<string, unknown> {
-  const question = acpPermissionQuestion(params);
+function normalizeAcpTerminalCreate(params: AcpTerminalCreateParams): AcpTerminalCreateParams {
+  if (params.cwd != null || (params.env?.length ?? 0) > 0) {
+    throw new Error('ACP terminal cwd and environment overrides are not supported');
+  }
+  const parsed =
+    params.args === undefined
+      ? parseAcpCommand(params.command)
+      : { command: params.command, args: params.args };
   return {
-    questions: [
-      {
-        question,
-        header: 'ACP approval',
-        options: params.options.map((option) => ({
-          label: option.name,
-          description: option.kind.replaceAll('_', ' '),
-        })),
-        multiSelect: false,
-      },
-    ],
+    ...params,
+    command: parsed.command,
+    args: parsed.args,
+    cwd: undefined,
+    env: undefined,
   };
 }
 
-async function handleAcpPermissionRequest(
-  params: AcpPermissionRequest,
-  canUseTool: CanUseTool
+async function allowAcpPermissionRequest(
+  params: AcpPermissionRequest
 ): Promise<AcpPermissionResponseResult> {
-  if (params.options.length === 0) {
-    return { outcome: { outcome: 'cancelled' } };
-  }
-
-  const controller = new AbortController();
-  const question = acpPermissionQuestion(params);
-  const result = await canUseTool('AskUserQuestion', acpPermissionQuestionInput(params), {
-    signal: controller.signal,
-    toolUseID: params.toolCall.toolCallId,
-    title: question,
-    displayName: params.toolCall.title ?? params.toolCall.kind ?? 'ACP tool',
-    description: params.toolCall.kind,
-    requestId: generateUUID(),
-  });
-
-  if (!result || result.behavior === 'deny') {
-    return { outcome: { outcome: 'cancelled' } };
-  }
-
-  const answers = (result.updatedInput as { answers?: Record<string, string> } | undefined)
-    ?.answers;
-  const selectedName = answers?.[question] ?? Object.values(answers ?? {})[0];
-  const selectedOption = params.options.find((option) => option.name === selectedName);
-
-  if (selectedOption) {
-    return { outcome: { outcome: 'selected', optionId: selectedOption.optionId } };
-  }
-
-  return { outcome: { outcome: 'cancelled' } };
+  const option =
+    params.options.find((candidate) => candidate.kind.startsWith('allow')) ?? params.options[0];
+  if (!option) return { outcome: { outcome: 'cancelled' } };
+  return { outcome: { outcome: 'selected', optionId: option.optionId } };
 }
+
 
 function systemPromptText(systemPrompt: Options['systemPrompt']): string[] {
   if (!systemPrompt) return [];
@@ -410,6 +391,7 @@ export class AcpQueryRunner {
     let receivedAcpMessageDuringRun = false;
     let restoreMessageEnqueuedHandler: (() => void) | undefined;
     let proxyBridge: AcpMcpProxyBridge | null = null;
+    let terminalManager: AcpTerminalManager | null = null;
     let turnCompletedNormally = false;
     let runAbortController: AbortController | null = this.ctx.queryAbortController;
 
@@ -496,7 +478,8 @@ export class AcpQueryRunner {
         (message) => logger.warn(message),
         proxyBridge
       );
-      const cwd = getAcpWorkspacePath(session, queryOptions);
+      const workspace = getAcpWorkspacePath(session, queryOptions);
+      const cwd = workspace ?? process.cwd();
       const startupTimeoutMs = getStartupTimeoutMs();
       const abortController = new AbortController();
       this.ctx.queryAbortController = abortController;
@@ -563,15 +546,49 @@ export class AcpQueryRunner {
         acpEnv.CLAUDE_CODE_OAUTH_TOKEN = preCleanupAuth.CLAUDE_CODE_OAUTH_TOKEN;
       }
 
+      const processTreeOwner = await getAcpProcessTreeOwner();
+      const hostCallbacks = workspace
+        ? (() => {
+            const manager = new AcpTerminalManager(
+              buildAcpSafeEnv(acpEnv),
+              workspace,
+              processTreeOwner
+            );
+            terminalManager = manager;
+            return {
+              onTerminalCreate: async (params: AcpTerminalCreateParams) => {
+                const normalized = normalizeAcpTerminalCreate(params);
+                if (abortController.signal.aborted) {
+                  throw new Error('ACP terminal command cancelled');
+                }
+                return manager.create(normalized);
+              },
+              onTerminalOutput: (params: AcpTerminalOutputParams) => manager.output(params),
+              onTerminalWaitForExit: (params: AcpTerminalWaitForExitParams) =>
+                manager.waitForExit(params),
+              onTerminalKill: (params: AcpTerminalKillParams) => manager.kill(params),
+              onTerminalRelease: (params: AcpTerminalReleaseParams) => manager.release(params),
+              ...(isSafeFsSupported()
+                ? {
+                    onFsRead: (params: AcpFsReadParams) => this.handleFsRead(params, workspace),
+                    onFsWrite: (params: AcpFsWriteParams) =>
+                      this.handleFsWrite(params, workspace, abortController.signal),
+                  }
+                : {}),
+            };
+          })()
+        : {};
       client = this.createAcpClient({
         command,
         args,
         cwd,
         env: acpEnv as Record<string, string> | undefined,
+        processTreeOwner,
         onProcessSpawn: (proc) =>
           this.ctx.trackAgentProcess(proc as unknown as TrackedAgentProcess),
         onStderr: (data) => logger.warn(`ACP agent stderr: ${data.trimEnd()}`),
-        onPermissionRequest: (params) => handleAcpPermissionRequest(params, canUseTool),
+        onPermissionRequest: allowAcpPermissionRequest,
+        ...hostCallbacks,
       });
 
       if (messageQueue.size() > 0) {
@@ -754,6 +771,8 @@ export class AcpQueryRunner {
         !runAbortController?.signal.aborted && stateManager.getState().status !== 'interrupted';
     } catch (error) {
       restoreMessageEnqueuedHandler?.();
+      terminalManager?.dispose();
+      terminalManager = null;
       const effectiveError =
         startupTimeoutReached && !this.ctx.firstMessageReceived
           ? new Error('ACP startup timeout - query aborted')
@@ -773,6 +792,7 @@ export class AcpQueryRunner {
       );
     } finally {
       restoreMessageEnqueuedHandler?.();
+      terminalManager?.dispose();
       await proxyBridge?.close();
       proxyBridge = null;
       const isStaleQuery = this.ctx.getQueryGeneration() !== queryGeneration;
@@ -971,6 +991,54 @@ export class AcpQueryRunner {
         );
         await stateManager.setIdle();
       }
+    }
+  }
+
+  private async handleFsRead(params: AcpFsReadParams, workspace: string): Promise<AcpFsReadResult> {
+    const { workspacePath, segments } = await this.resolveWorkspaceSegments(params.path, workspace);
+    return {
+      content: await readFileWithinWorkspace(workspacePath, segments, {
+        startLine: Math.max(0, (params.line ?? 1) - 1),
+        lineLimit: params.limit ?? undefined,
+        maxBytes: MAX_FS_READ_BYTES,
+      }),
+    };
+  }
+
+  private async handleFsWrite(
+    params: AcpFsWriteParams,
+    workspace: string,
+    signal: AbortSignal
+  ): Promise<AcpFsWriteResult> {
+    if (signal.aborted) throw new Error('ACP filesystem write cancelled');
+    const { workspacePath, segments } = await this.resolveWorkspaceSegments(params.path, workspace);
+    await writeFileWithinWorkspace(workspacePath, segments, params.content, signal);
+    return {};
+  }
+
+  private async resolveWorkspaceSegments(
+    path: string,
+    workspace: string
+  ): Promise<{ workspacePath: string; segments: string[] }> {
+    const { realpath } = await import('node:fs/promises');
+    const workspacePath = await realpath(workspace);
+    const lexicalWorkspace = resolve(workspace);
+    const requestedPath = isAbsolute(path) ? resolve(path) : resolve(lexicalWorkspace, path);
+    let relativePath = relative(lexicalWorkspace, requestedPath);
+    try {
+      this.assertWorkspacePath(requestedPath, lexicalWorkspace, path);
+    } catch {
+      this.assertWorkspacePath(requestedPath, workspacePath, path);
+      relativePath = relative(workspacePath, requestedPath);
+    }
+    if (!relativePath) throw new Error(`ACP filesystem path must identify a file: ${path}`);
+    return { workspacePath, segments: relativePath.split(sep) };
+  }
+
+  private assertWorkspacePath(path: string, workspace: string, requestedPath: string): void {
+    const relativePath = relative(workspace, path);
+    if (relativePath === '..' || relativePath.startsWith(`..${sep}`) || isAbsolute(relativePath)) {
+      throw new Error(`ACP filesystem path escapes workspace: ${requestedPath}`);
     }
   }
 

--- a/packages/daemon/src/lib/acp/acp-query-runner.ts
+++ b/packages/daemon/src/lib/acp/acp-query-runner.ts
@@ -47,7 +47,11 @@ import { AcpClient, type AcpClientOptions } from './acp-client';
 import { buildAcpSafeEnv, getAcpCommandIdentityDigest, parseAcpCommand } from './acp-command';
 import { getAcpProcessTreeOwner } from './acp-process-tree';
 import { AcpQueryAdapter } from './acp-query-adapter';
-import { isSafeFsSupported, readFileWithinWorkspace, writeFileWithinWorkspace } from './acp-safe-fs';
+import {
+  isSafeFsSupported,
+  readFileWithinWorkspace,
+  writeFileWithinWorkspace,
+} from './acp-safe-fs';
 import { AcpTerminalManager } from './acp-terminal-manager';
 import { AcpMcpProxyBridge, shouldProxy } from './mcp-proxy-bridge';
 
@@ -294,7 +298,6 @@ async function allowAcpPermissionRequest(
   if (!option) return { outcome: { outcome: 'cancelled' } };
   return { outcome: { outcome: 'selected', optionId: option.optionId } };
 }
-
 
 function systemPromptText(systemPrompt: Options['systemPrompt']): string[] {
   if (!systemPrompt) return [];

--- a/packages/daemon/tests/unit/lib/acp/acp-query-runner.test.ts
+++ b/packages/daemon/tests/unit/lib/acp/acp-query-runner.test.ts
@@ -1,4 +1,7 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
+import { mkdir, mkdtemp, readFile, realpath, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { z } from 'zod';
 import type { MessageContent, MessageHub, Session } from '@hyperneo/shared';
 import type { SDKMessage, SDKUserMessage } from '@hyperneo/shared/sdk';
@@ -52,6 +55,27 @@ function createMockClient() {
     close: mock(() => {}),
     cancel: mock(() => {}),
   };
+}
+
+function createHeldPromptClient() {
+  let markPromptStarted: (() => void) | undefined;
+  let releasePrompt: (() => void) | undefined;
+  const promptStarted = new Promise<void>((resolve) => {
+    markPromptStarted = resolve;
+  });
+  const client = createMockClient();
+  client.sendPrompt = mock(async function* (
+    _prompt: unknown,
+    callbacks?: { onSubmitted?: () => void; onAccepted?: () => void }
+  ) {
+    callbacks?.onSubmitted?.();
+    callbacks?.onAccepted?.();
+    markPromptStarted?.();
+    await new Promise<void>((resolve) => {
+      releasePrompt = resolve;
+    });
+  });
+  return { client, promptStarted, releasePrompt: () => releasePrompt?.() };
 }
 
 function makeUserMessage(content: string | MessageContent[]): SDKUserMessage {
@@ -793,13 +817,8 @@ describe('AcpQueryRunner', () => {
     expect(constructorOptions[0].args).toEqual(['--stdio']);
   });
 
-  test('maps ACP permission requests through AskUserQuestion approval callback', async () => {
-    const { runner, ctx, constructorOptions, canUseTool } = createRunnerFixture({
-      canUseTool: async (_toolName, _input, _options) => ({
-        behavior: 'allow',
-        updatedInput: { answers: { 'Allow Edit file?': 'Allow once' } },
-      }),
-    });
+  test('auto-allows ACP permission requests without prompting the user', async () => {
+    const { runner, ctx, constructorOptions, canUseTool } = createRunnerFixture();
 
     await runner.start();
     await ctx.queryPromise;
@@ -817,19 +836,230 @@ describe('AcpQueryRunner', () => {
       ],
     });
 
-    expect(canUseTool).toHaveBeenCalledWith(
-      'AskUserQuestion',
-      expect.objectContaining({
-        questions: [
-          expect.objectContaining({
-            question: 'Allow Edit file?',
-            header: 'ACP approval',
-          }),
-        ],
-      }),
-      expect.objectContaining({ toolUseID: 'tool-1' })
-    );
     expect(result).toEqual({ outcome: { outcome: 'selected', optionId: 'allow-once' } });
+    expect(canUseTool).not.toHaveBeenCalled();
+  });
+
+
+  test('rejects filesystem callbacks that escape the workspace', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'hyperneo-acp-escape-'));
+    const workspace = join(root, 'workspace');
+    const outside = join(root, 'outside.txt');
+    await mkdir(workspace);
+    await writeFile(outside, 'secret');
+    const { client, promptStarted, releasePrompt } = createHeldPromptClient();
+    const { runner, ctx, constructorOptions } = createRunnerFixture({
+      client,
+      session: { workspacePath: workspace },
+      queryOptions: { cwd: workspace, mcpServers: {} },
+    });
+
+    try {
+      await runner.start();
+      await promptStarted;
+
+      await expect(
+        constructorOptions[0].onFsRead?.({
+          sessionId: 'acp-session-1',
+          path: outside,
+        })
+      ).rejects.toThrow('escapes workspace');
+      await expect(
+        constructorOptions[0].onFsRead?.({
+          sessionId: 'acp-session-1',
+          path: '../outside.txt',
+        })
+      ).rejects.toThrow('escapes workspace');
+      await expect(
+        constructorOptions[0].onFsRead?.({
+          sessionId: 'acp-session-1',
+          path: workspace,
+        })
+      ).rejects.toThrow('must identify a file');
+      await expect(
+        constructorOptions[0].onFsWrite?.({
+          sessionId: 'acp-session-1',
+          path: '../escaped.txt',
+          content: 'blocked',
+        })
+      ).rejects.toThrow('escapes workspace');
+      expect(await readFile(outside, 'utf-8')).toBe('secret');
+      releasePrompt();
+      await ctx.queryPromise;
+    } finally {
+      releasePrompt();
+      await rm(root, { recursive: true, force: true });
+    }
+  }, 10000);
+
+  test('confines filesystem callbacks to the workspace and honors read ranges', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'hyperneo-acp-fs-'));
+    const workspace = join(root, 'workspace');
+    await mkdir(workspace);
+    await writeFile(join(workspace, 'inside.txt'), 'one\ntwo\nthree\nfour');
+    const { client, promptStarted, releasePrompt } = createHeldPromptClient();
+    const { runner, ctx, constructorOptions } = createRunnerFixture({
+      client,
+      session: { workspacePath: workspace },
+      queryOptions: { cwd: workspace, mcpServers: {} },
+    });
+
+    try {
+      await runner.start();
+      await promptStarted;
+
+      await expect(
+        constructorOptions[0].onFsRead?.({
+          sessionId: 'acp-session-1',
+          path: join(workspace, 'inside.txt'),
+          line: 2,
+          limit: 2,
+        })
+      ).resolves.toEqual({ content: 'two\nthree\n' });
+      await expect(
+        constructorOptions[0].onFsRead?.({
+          sessionId: 'acp-session-1',
+          path: join(await realpath(workspace), 'inside.txt'),
+        })
+      ).resolves.toEqual({ content: 'one\ntwo\nthree\nfour' });
+      await constructorOptions[0].onFsWrite?.({
+        sessionId: 'acp-session-1',
+        path: join(workspace, 'nested', 'written.txt'),
+        content: 'written',
+      });
+      expect(await readFile(join(workspace, 'nested', 'written.txt'), 'utf-8')).toBe('written');
+      await constructorOptions[0].onFsWrite?.({
+        sessionId: 'acp-session-1',
+        path: '..hidden/written.txt',
+        content: 'hidden',
+      });
+      expect(await readFile(join(workspace, '..hidden', 'written.txt'), 'utf-8')).toBe('hidden');
+      releasePrompt();
+      await ctx.queryPromise;
+    } finally {
+      releasePrompt();
+      await rm(root, { recursive: true, force: true });
+    }
+  }, 10000);
+
+  test('starts workspace-less ACP sessions without host filesystem or terminal callbacks', async () => {
+    const { runner, ctx, constructorOptions } = createRunnerFixture({
+      session: { workspacePath: undefined },
+      queryOptions: { mcpServers: {} },
+    });
+
+    await runner.start();
+    await ctx.queryPromise;
+
+    expect(constructorOptions).toHaveLength(1);
+    expect(constructorOptions[0]).toMatchObject({ cwd: process.cwd() });
+    expect(constructorOptions[0].onFsRead).toBeUndefined();
+    expect(constructorOptions[0].onFsWrite).toBeUndefined();
+    expect(constructorOptions[0].onTerminalCreate).toBeUndefined();
+    expect(constructorOptions[0].onTerminalOutput).toBeUndefined();
+    expect(constructorOptions[0].onTerminalWaitForExit).toBeUndefined();
+    expect(constructorOptions[0].onTerminalKill).toBeUndefined();
+    expect(constructorOptions[0].onTerminalRelease).toBeUndefined();
+    expect(ctx.errorManager.handleError).not.toHaveBeenCalled();
+  });
+
+  test('uses an allowlisted environment for ACP terminal commands', async () => {
+    const previousGithubToken = process.env.GITHUB_TOKEN;
+    process.env.GITHUB_TOKEN = 'github-secret';
+    process.env.ANTHROPIC_AUTH_TOKEN = 'sk-ant-oat-acp-token';
+    const { client, promptStarted, releasePrompt } = createHeldPromptClient();
+    const { runner, ctx, constructorOptions } = createRunnerFixture({
+      client,
+      queryOptions: {
+        cwd: '/tmp/acp-session',
+        mcpServers: {},
+        env: { HTTPS_PROXY: 'http://session-proxy.example:8080' },
+      },
+    });
+
+    try {
+      await runner.start();
+      await promptStarted;
+      const created = await constructorOptions[0].onTerminalCreate?.({
+        sessionId: 'acp-session-1',
+        command: process.execPath,
+        args: ['-e', 'console.log(JSON.stringify(process.env))'],
+      });
+      if (!created) throw new Error('ACP terminal was not created');
+      await constructorOptions[0].onTerminalWaitForExit?.({
+        sessionId: 'acp-session-1',
+        terminalId: created.terminalId,
+      });
+      let terminalEnv: Record<string, string> | undefined;
+      const outputDeadline = Date.now() + 5000;
+      while (terminalEnv === undefined) {
+        const output = await constructorOptions[0].onTerminalOutput?.({
+          sessionId: 'acp-session-1',
+          terminalId: created.terminalId,
+        });
+        const text = output?.output.trim() ?? '';
+        if (text) {
+          terminalEnv = JSON.parse(text) as Record<string, string>;
+        } else {
+          if (Date.now() > outputDeadline) throw new Error('ACP terminal produced no output');
+          await new Promise((resolve) => setTimeout(resolve, 10));
+        }
+      }
+
+      expect(terminalEnv.PATH).toBe(process.env.PATH);
+      expect(terminalEnv.HTTPS_PROXY).toBe('http://session-proxy.example:8080');
+      expect(terminalEnv.GITHUB_TOKEN).toBeUndefined();
+      expect(terminalEnv.ANTHROPIC_AUTH_TOKEN).toBeUndefined();
+    } finally {
+      releasePrompt();
+      await ctx.queryPromise;
+      if (previousGithubToken === undefined) delete process.env.GITHUB_TOKEN;
+      else process.env.GITHUB_TOKEN = previousGithubToken;
+    }
+  }, 20000);
+
+  test('rejects terminal cwd and environment overrides', async () => {
+    const { runner, ctx, constructorOptions, canUseTool } = createRunnerFixture();
+
+    await runner.start();
+    await ctx.queryPromise;
+
+    await expect(
+      constructorOptions[0].onTerminalCreate?.({
+        sessionId: 'acp-session-1',
+        command: 'git',
+        args: ['status'],
+        cwd: '/tmp',
+      })
+    ).rejects.toThrow('ACP terminal cwd and environment overrides are not supported');
+    await expect(
+      constructorOptions[0].onTerminalCreate?.({
+        sessionId: 'acp-session-1',
+        command: 'git',
+        args: ['status'],
+        env: [{ name: 'PATH', value: '/tmp/bin' }],
+      })
+    ).rejects.toThrow('ACP terminal cwd and environment overrides are not supported');
+    expect(canUseTool).not.toHaveBeenCalled();
+  });
+
+  test('does not create terminals after the query has aborted', async () => {
+    const { client, promptStarted, releasePrompt } = createHeldPromptClient();
+    const { runner, ctx, constructorOptions } = createRunnerFixture({ client });
+
+    await runner.start();
+    await promptStarted;
+    ctx.queryAbortController?.abort();
+
+    await expect(
+      constructorOptions[0].onTerminalCreate?.({
+        sessionId: 'acp-session-1',
+        command: process.execPath,
+        args: ['-e', 'process.exit(0)'],
+      })
+    ).rejects.toThrow('ACP terminal command cancelled');
+    releasePrompt();
+    await ctx.queryPromise;
   });
 
   test('persists new ACP session ids', async () => {

--- a/packages/daemon/tests/unit/lib/acp/acp-query-runner.test.ts
+++ b/packages/daemon/tests/unit/lib/acp/acp-query-runner.test.ts
@@ -21,6 +21,7 @@ import {
   parseAcpCommand,
 } from '../../../../src/lib/acp/acp-query-runner';
 import { AcpMcpProxyBridge } from '../../../../src/lib/acp/mcp-proxy-bridge';
+import { readFileWithinWorkspace } from '../../../../src/lib/acp/acp-safe-fs';
 import { resetProviderFactory } from '../../../../src/lib/providers/factory';
 import { getProviderRegistry, resetProviderRegistry } from '../../../../src/lib/providers/registry';
 import { AcpProvider } from '../../../../src/lib/providers/acp-provider';
@@ -55,6 +56,21 @@ function createMockClient() {
     close: mock(() => {}),
     cancel: mock(() => {}),
   };
+}
+
+async function safeFsBackendAvailable(): Promise<boolean> {
+  try {
+    const root = await mkdtemp(join(tmpdir(), 'hyperneo-acp-probe-'));
+    try {
+      await writeFile(join(root, 'probe.txt'), 'x');
+      await readFileWithinWorkspace(root, ['probe.txt'], { maxBytes: 8 });
+      return true;
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  } catch {
+    return false;
+  }
 }
 
 function createHeldPromptClient() {
@@ -840,8 +856,8 @@ describe('AcpQueryRunner', () => {
     expect(canUseTool).not.toHaveBeenCalled();
   });
 
-
   test('rejects filesystem callbacks that escape the workspace', async () => {
+    if (!(await safeFsBackendAvailable())) return;
     const root = await mkdtemp(join(tmpdir(), 'hyperneo-acp-escape-'));
     const workspace = join(root, 'workspace');
     const outside = join(root, 'outside.txt');
@@ -893,6 +909,7 @@ describe('AcpQueryRunner', () => {
   }, 10000);
 
   test('confines filesystem callbacks to the workspace and honors read ranges', async () => {
+    if (!(await safeFsBackendAvailable())) return;
     const root = await mkdtemp(join(tmpdir(), 'hyperneo-acp-fs-'));
     const workspace = join(root, 'workspace');
     await mkdir(workspace);


### PR DESCRIPTION
Extracted from #2711 (ACP split 8/10).

## What this adds

- **Terminal callbacks**: when the session has a workspace, query startup constructs an `AcpTerminalManager` (allowlisted env via `buildAcpSafeEnv`, workspace as default cwd, process-tree owner) and wires `terminal/create|output|wait_for_exit|kill|release`. Commands are parsed/normalized, `cwd`/`env` overrides on terminal creation are rejected, and terminals are not created after the query aborts. Manager disposal runs on both the error path (early) and in `finally`.
- **Safe-filesystem callbacks**: `fs/read_text_file` / `fs/write_text_file` route through the workspace-confined safe-fs layer with a 4 MiB read cap, line/limit ranges, realpath-aware boundary checks, and abort-aware writes. Workspace-less sessions register no host callbacks and fall back to `process.cwd()` for the agent cwd.
- **Bypass permissions**: `session/request_permission` from the agent is auto-allowed (first `allow_*` option) — the same trust model the Claude SDK path runs under. The AskUserQuestion-based ACP approval gate that was on dev is removed; the unified approval/permission UX for both providers is deferred design work tracked in #2782.
- 7 new/ported tests: workspace-escape rejection, read ranges + write containment, workspace-less sessions, terminal env allowlist, override rejection, post-abort cancellation, auto-allowed permissions.

## Deliberately not here

- Approval-gated variants of these callbacks (AskUserQuestion wiring, display limits, abortable permission prompts, secret redaction in prompts) — parked in #2782 / #2781 with the security-hardening decision.
- Transport shutdown-ladder and abort/interrupt hardening — next slices in this stack.

Extracted from #2711.

## Verification

- `bun test tests/unit/lib/acp/acp-query-runner.test.ts` — 54/54 (includes real-subprocess terminal test at a 20s budget)
- oxlint, `tsc --build --noEmit`, knip, pinned-biome format — clean
- Full `tests/unit/lib/acp/` sandbox run matches the pre-existing environmental baseline (AcpClient/mock-server noise) except the real-subprocess allowlist test, which passes in isolation and hangs only in the sandbox's polluted full-dir run; CI shard boundaries differ and ran this suite green on the source branch
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/lsm/hyperneo/pull/2786" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->