### PR TITLE
refactor(space): apply verified-stop stagedRun as the stopSessionVerified interpreter (superpipe S5 PR 5/6)

### DIFF
--- a/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
+++ b/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
@@ -92,13 +92,6 @@ import {
   resolveSpawnWorkspace,
   resolveWorkflowNodeSlot,
 } from './spawn-slot-resolution';
-import {
-  assembleVerifiedStopResult,
-  decideStopVerification,
-  isStopDownProcessingStatus,
-  type StopVerificationDecision,
-  type StopVerificationSnapshot,
-} from './stop-verification-gates';
 import { runVerifiedStopFlow, type VerifiedStopFlowDeps } from './verified-stop-flow';
 import { sanitizeAssistantUsageInSDKSessionFile } from '../../sdk-session-file-manager';
 import { ChannelResolver } from './channel-resolver';
@@ -2506,96 +2499,13 @@ export class TaskAgentManager {
   private async stopSessionVerified(sessionId: string): Promise<VerifiedSessionStop> {
     this.cancellingSessions.add(sessionId);
     try {
-      const session =
-        this.agentSessionIndex.get(sessionId) ??
-        this.config.sessionManager?.getCachedSession(sessionId) ??
-        null;
-      this.agentSessionIndex.delete(sessionId);
-
-      if (!session) {
-        try {
-          await this.config.sessionManager?.unregisterSession?.(sessionId);
-        } catch (err) {
-          log.warn(
-            `TaskAgentManager.stopSessionsVerified: failed to unregister missing session ${sessionId}:`,
-            err
-          );
-        }
-        return { sessionId, stopped: true, detail: 'no in-memory session; unregistered' };
-      }
-
-      const notes: string[] = [];
-      let interruptAttemptsSoFar = 0;
-      let escalationDone = false;
-
-      const attemptInterrupt = async (failureNote: string): Promise<void> => {
-        try {
-          await this.stopSessionPreserveDb(sessionId, session, { strict: true });
-        } catch (err) {
-          notes.push(`${failureNote}: ${err instanceof Error ? err.message : String(err)}`);
-        }
-        interruptAttemptsSoFar += 1;
-      };
-
-      const decideNextStopAction = async (): Promise<StopVerificationDecision> =>
-        decideStopVerification(
-          await this.gatherStopVerificationSnapshot(session, interruptAttemptsSoFar, escalationDone)
-        );
-
-      await attemptInterrupt('interrupt failed');
-
-      let decision = await decideNextStopAction();
-      while (decision.action === 'retry_interrupt' || decision.action === 'escalate_terminate') {
-        if (decision.action === 'retry_interrupt') {
-          log.warn(
-            `TaskAgentManager.stopSessionsVerified: session ${sessionId} still alive after interrupt (${decision.reason}); retrying once`
-          );
-          await attemptInterrupt('retry interrupt failed');
-          decision = await decideNextStopAction();
-          if (decision.action === 'down') {
-            notes.push('first interrupt did not land; stopped on retry');
-          }
-          continue;
-        }
-        log.warn(
-          `TaskAgentManager.stopSessionsVerified: session ${sessionId} survived interrupt retry (${decision.reason}); escalating to tracked process termination`
-        );
-        notes.push(`escalated after verification failure (${decision.reason})`);
-        try {
-          session.terminateTrackedAgentProcesses({
-            forceDelayMs: VERIFIED_STOP_ESCALATION_FORCE_KILL_MS,
-          });
-        } catch (err) {
-          notes.push(`escalation failed: ${err instanceof Error ? err.message : String(err)}`);
-        }
-        escalationDone = true;
-        decision = await decideNextStopAction();
-      }
-
-      this.detachSessionBookkeeping(sessionId);
-
-      try {
-        await this.config.sessionManager?.unregisterSession?.(sessionId);
-      } catch (err) {
-        notes.push(`unregister failed: ${err instanceof Error ? err.message : String(err)}`);
-      }
-
-      return assembleVerifiedStopResult({ sessionId, notes, decision });
-    } finally {
-      this.cancellingSessions.delete(sessionId);
-    }
-  }
-
-  async stopSessionVerifiedViaFlow(sessionId: string): Promise<VerifiedSessionStop> {
-    this.cancellingSessions.add(sessionId);
-    try {
       const outcome = await runVerifiedStopFlow(this.buildVerifiedStopFlowDeps(), sessionId);
       if (outcome.status === 'error') {
         throw outcome.error;
       }
       if (outcome.status === 'superseded') {
         throw new Error(
-          `TaskAgentManager.stopSessionVerifiedViaFlow: verified stop for session ${sessionId} superseded at stage ${outcome.stage ?? 'unknown'}`
+          `TaskAgentManager.stopSessionVerified: verified stop for session ${sessionId} superseded at stage ${outcome.stage ?? 'unknown'}`
         );
       }
       return outcome.result as VerifiedSessionStop;
@@ -2637,33 +2547,6 @@ export class TaskAgentManager {
         log.warn(message, err);
       },
     };
-  }
-
-  private async gatherStopVerificationSnapshot(
-    session: AgentSession,
-    interruptAttemptsSoFar: number,
-    escalationDone: boolean
-  ): Promise<StopVerificationSnapshot> {
-    const processingStatus = session.getProcessingState().status;
-    const interruptInProgress =
-      isStopDownProcessingStatus(processingStatus) && session.isInterruptInProgress();
-    const livePids =
-      isStopDownProcessingStatus(processingStatus) && !interruptInProgress
-        ? await this.readLivePidsAfterSettle(session)
-        : [];
-    return {
-      sessionPresent: true,
-      processingStatus,
-      interruptInProgress,
-      livePids,
-      interruptAttemptsSoFar,
-      escalationDone,
-    };
-  }
-
-  private async readLivePidsAfterSettle(session: AgentSession): Promise<number[]> {
-    await this.awaitSessionProcessExit(session, VERIFIED_STOP_PROCESS_EXIT_SETTLE_MS);
-    return session.getTrackedAgentRootPidsSplit().live;
   }
 
   private async awaitSessionProcessExit(session: AgentSession, timeoutMs: number): Promise<void> {

--- a/packages/daemon/tests/unit/5-space/runtime/task-agent-manager-stop-verified-flow.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/task-agent-manager-stop-verified-flow.test.ts
@@ -1,6 +1,7 @@
 import { Database as BunDatabase } from 'bun:sqlite';
 import { describe, expect, test } from 'bun:test';
 import type { AgentSession } from '../../../../src/lib/agent/agent-session.ts';
+import type { VerifiedSessionStop } from '../../../../src/lib/space/runtime/task-agent-manager.ts';
 import { TaskAgentManager } from '../../../../src/lib/space/runtime/task-agent-manager.ts';
 
 interface FakeInterruptOptions {
@@ -148,14 +149,22 @@ function tick(): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, 0));
 }
 
-describe('TaskAgentManager.stopSessionVerifiedViaFlow', () => {
+function stopVerified(manager: TaskAgentManager, sessionId: string): Promise<VerifiedSessionStop> {
+  return (
+    manager as unknown as {
+      stopSessionVerified(sessionId: string): Promise<VerifiedSessionStop>;
+    }
+  ).stopSessionVerified(sessionId);
+}
+
+describe('TaskAgentManager.stopSessionVerified stagedRun interpreter', () => {
   test('happy path: interrupts once, verifies down, detaches, and unregisters', async () => {
     const sessionManager = makeSessionManager();
     const manager = makeManager(sessionManager);
     const fake = makeFakeSession({ statusSequence: ['processing', 'idle'] });
     registerSession(manager, 'task-1', 'sess-1', fake.session);
 
-    const result = await manager.stopSessionVerifiedViaFlow('sess-1');
+    const result = await stopVerified(manager, 'sess-1');
 
     expect(fake.calls.interrupts).toBe(1);
     expect(fake.calls.cleanups).toBeGreaterThanOrEqual(1);
@@ -174,7 +183,7 @@ describe('TaskAgentManager.stopSessionVerifiedViaFlow', () => {
     const sessionManager = makeSessionManager();
     const manager = makeManager(sessionManager);
 
-    const result = await manager.stopSessionVerifiedViaFlow('ghost-session');
+    const result = await stopVerified(manager, 'ghost-session');
 
     expect(result).toEqual({
       sessionId: 'ghost-session',
@@ -188,7 +197,7 @@ describe('TaskAgentManager.stopSessionVerifiedViaFlow', () => {
     const sessionManager = makeSessionManager({ failUnregisterFor: ['ghost'] });
     const manager = makeManager(sessionManager);
 
-    const result = await manager.stopSessionVerifiedViaFlow('ghost');
+    const result = await stopVerified(manager, 'ghost');
 
     expect(result).toEqual({
       sessionId: 'ghost',
@@ -203,7 +212,7 @@ describe('TaskAgentManager.stopSessionVerifiedViaFlow', () => {
     const fake = makeFakeSession({ statusSequence: ['processing', 'processing', 'idle'] });
     registerSession(manager, 'task-1', 'sess-1', fake.session);
 
-    const result = await manager.stopSessionVerifiedViaFlow('sess-1');
+    const result = await stopVerified(manager, 'sess-1');
 
     expect(fake.calls.interrupts).toBe(2);
     expect(fake.calls.terminations).toBe(0);
@@ -223,7 +232,7 @@ describe('TaskAgentManager.stopSessionVerifiedViaFlow', () => {
     });
     registerSession(manager, 'task-1', 'sess-1', fake.session);
 
-    const result = await manager.stopSessionVerifiedViaFlow('sess-1');
+    const result = await stopVerified(manager, 'sess-1');
 
     expect(fake.calls.interrupts).toBe(2);
     expect(result.stopped).toBe(true);
@@ -238,7 +247,7 @@ describe('TaskAgentManager.stopSessionVerifiedViaFlow', () => {
     const fake = makeFakeSession({ statusSequence: ['processing'] });
     registerSession(manager, 'task-1', 'sess-1', fake.session);
 
-    const result = await manager.stopSessionVerifiedViaFlow('sess-1');
+    const result = await stopVerified(manager, 'sess-1');
 
     expect(fake.calls.interrupts).toBe(2);
     expect(fake.calls.terminations).toBe(1);
@@ -265,7 +274,7 @@ describe('TaskAgentManager.stopSessionVerifiedViaFlow', () => {
     });
     registerSession(manager, 'task-1', 'sess-1', fake.session);
 
-    const result = await manager.stopSessionVerifiedViaFlow('sess-1');
+    const result = await stopVerified(manager, 'sess-1');
 
     expect(fake.calls.terminations).toBe(1);
     expect(result.stopped).toBe(true);
@@ -281,7 +290,7 @@ describe('TaskAgentManager.stopSessionVerifiedViaFlow', () => {
     });
     registerSession(manager, 'task-1', 'sess-1', fake.session);
 
-    const result = await manager.stopSessionVerifiedViaFlow('sess-1');
+    const result = await stopVerified(manager, 'sess-1');
 
     expect(fake.calls.interrupts).toBe(2);
     expect(fake.calls.terminations).toBe(1);
@@ -295,7 +304,7 @@ describe('TaskAgentManager.stopSessionVerifiedViaFlow', () => {
     const fake = makeFakeSession({ statusSequence: ['processing', 'idle'] });
     registerSession(manager, 'task-1', 'sess-1', fake.session);
 
-    const result = await manager.stopSessionVerifiedViaFlow('sess-1');
+    const result = await stopVerified(manager, 'sess-1');
 
     expect(result).toEqual({
       sessionId: 'sess-1',
@@ -314,7 +323,7 @@ describe('TaskAgentManager.stopSessionVerifiedViaFlow', () => {
     internals.sessionListeners.set('sess-1', () => events.push('listener-unsub'));
     internals.completionCallbacks.set('sess-1', () => {});
 
-    await manager.stopSessionVerifiedViaFlow('sess-1');
+    await stopVerified(manager, 'sess-1');
 
     expect(events).toEqual(['listener-unsub', 'unregister']);
     expect(internals.sessionListeners.has('sess-1')).toBe(false);
@@ -330,7 +339,7 @@ describe('TaskAgentManager.stopSessionVerifiedViaFlow', () => {
     const fake = makeFakeSession({ statusSequence: ['processing', 'idle'], interruptGate: gate });
     registerSession(manager, 'task-1', 'sess-1', fake.session);
 
-    const promise = manager.stopSessionVerifiedViaFlow('sess-1');
+    const promise = stopVerified(manager, 'sess-1');
     await Promise.resolve();
     await Promise.resolve();
     expect(internalsOf(manager).cancellingSessions.has('sess-1')).toBe(true);
@@ -350,7 +359,7 @@ describe('TaskAgentManager.stopSessionVerifiedViaFlow', () => {
     const fake = makeFakeSession({ statusSequence: ['processing', 'idle'], interruptGate: gate });
     registerSession(manager, 'task-1', 'sess-1', fake.session);
 
-    const promise = manager.stopSessionVerifiedViaFlow('sess-1');
+    const promise = stopVerified(manager, 'sess-1');
     await Promise.resolve();
     await Promise.resolve();
     const internals = internalsOf(manager);
@@ -376,7 +385,7 @@ describe('TaskAgentManager.stopSessionVerifiedViaFlow', () => {
     registerSession(manager, 'task-1', 'sess-1', fake.session);
 
     let settled = false;
-    const promise = manager.stopSessionVerifiedViaFlow('sess-1').then((result) => {
+    const promise = stopVerified(manager, 'sess-1').then((result) => {
       settled = true;
       return result;
     });
@@ -398,7 +407,7 @@ describe('TaskAgentManager.stopSessionVerifiedViaFlow', () => {
     const fake = makeFakeSession({ processingStateError: new Error('status blew up') });
     registerSession(manager, 'task-1', 'sess-1', fake.session);
 
-    await expect(manager.stopSessionVerifiedViaFlow('sess-1')).rejects.toThrow('status blew up');
+    await expect(stopVerified(manager, 'sess-1')).rejects.toThrow('status blew up');
     expect(fake.calls.interrupts).toBe(1);
     expect(internalsOf(manager).cancellingSessions.has('sess-1')).toBe(false);
   });
@@ -409,7 +418,7 @@ describe('TaskAgentManager.stopSessionVerifiedViaFlow', () => {
     const fake = makeFakeSession({ statusSequence: ['interrupted'] });
     registerSession(manager, 'task-1', 'sess-1', fake.session);
 
-    const result = await manager.stopSessionVerifiedViaFlow('sess-1');
+    const result = await stopVerified(manager, 'sess-1');
 
     expect(fake.calls.interrupts).toBe(1);
     expect(fake.calls.terminations).toBe(0);


### PR DESCRIPTION
## Summary

Chain S PR 5/6 — the apply step. `stopSessionVerified` in `task-agent-manager.ts` now **is** the stagedRun interpreter composed in S4 (#2763): the inline cascade is deleted and the method body is the flow wrapper (cancelling-guard + `runVerifiedStopFlow` + outcome mapping).

- `inspectSessionDown` decision logic lives entirely behind the S3 gates (`decideStopVerification`); the process-exit settle await is now a resnapshot stage body (`gatherSessionLiveness` in `verified-stop-flow.ts`).
- Deleted: the S4 additive shim `stopSessionVerifiedViaFlow` (folded into `stopSessionVerified`), the cascade-only `gatherStopVerificationSnapshot` / `readLivePidsAfterSettle` helpers, and the now-unused `stop-verification-gates` imports in the manager. Net −108 lines.
- The shell is untouched: `stopSessionsVerified` keeps the `Promise.all` fan-out and per-session crash containment.

## Parity proof (ADR 0004 testing convention 6c)

The pre-existing scenario suites pass **unchanged** (zero edits to them in this diff):

- `task-agent-manager-stop-verified.test.ts` (S1-extended) — every ladder/detail-string pin, the synchronous fan-out pin, the gated-settle pin, and the real-manager `parkStoppedWorkflowTask` ladder
- `task-agent-manager-cancel.test.ts`
- `task-agent-manager-contract.test.ts`
- park/stop paths (`parkStoppedWorkflowTask`, `stopSpace`/`stopActiveWork`) — the runtime-level suites inject fake TAMs, so they cover the untouched shell

Only edit outside the manager: the S4 flow test retargets mechanically to the folded private method via a cast helper (same pattern the S1 suite uses for `stopSessionPreserveDb`); its scenario bodies are unchanged. The S4 microtask-profile pins (`claim + interrupt before the first await boundary`; one queued observer between interrupt and verification) already cover the async resnapshot stages, so no new pinning was needed; will add pins if CI flutters (ADR condition 4).

## Test plan

- [ ] CI: daemon shards (5-space runtime/agent), full `make check`
- [ ] Parity suites green without modification
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/lsm/hyperneo/pull/2787" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->