### PR TITLE
refactor(web): pin and migrate useGroupMessages onto live-query-lifecycle (task #1255)

### DIFF
--- a/packages/web/src/hooks/__tests__/useGroupMessages.lifecycle.test.ts
+++ b/packages/web/src/hooks/__tests__/useGroupMessages.lifecycle.test.ts
@@ -1,0 +1,397 @@
+import { act, renderHook } from '@testing-library/preact';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { mockRequest, mockOnEvent, mockIsConnected } = vi.hoisted(() => ({
+  mockRequest: vi.fn().mockResolvedValue({ ok: true }),
+  mockOnEvent: vi.fn<(method: string, handler: (event: unknown) => void) => () => void>(
+    () => () => {}
+  ),
+  mockIsConnected: { value: true },
+}));
+
+vi.mock('../useMessageHub', () => ({
+  useMessageHub: () => ({
+    request: mockRequest,
+    onEvent: mockOnEvent,
+    get isConnected() {
+      return mockIsConnected.value;
+    },
+  }),
+}));
+
+type EventHandler = (event: unknown) => void;
+let eventHandlers: Record<string, EventHandler[]> = {};
+
+function fireEvent(method: string, payload: unknown): void {
+  (eventHandlers[method] ?? []).forEach((h) => h(payload));
+}
+
+function subscribeCalls() {
+  return mockRequest.mock.calls.filter((call) => call[0] === 'liveQuery.subscribe');
+}
+
+function unsubscribeCalls() {
+  return mockRequest.mock.calls.filter((call) => call[0] === 'liveQuery.unsubscribe');
+}
+
+function makeMessage(id: number, content = `msg-${id}`) {
+  return {
+    id,
+    groupId: 'group-1',
+    sessionId: null,
+    role: 'assistant',
+    messageType: 'text',
+    content,
+    createdAt: 1_000_000 + id,
+  };
+}
+
+import { useGroupMessages, type SessionGroupMessage } from '../useGroupMessages';
+
+describe('useGroupMessages liveQuery lifecycle', () => {
+  beforeEach(() => {
+    vi.useRealTimers();
+    mockRequest.mockReset();
+    mockOnEvent.mockReset();
+    mockRequest.mockResolvedValue({ ok: true });
+    mockIsConnected.value = true;
+    eventHandlers = {};
+    mockOnEvent.mockImplementation((method: string, handler: EventHandler) => {
+      if (!eventHandlers[method]) eventHandlers[method] = [];
+      eventHandlers[method].push(handler);
+      return () => {
+        eventHandlers[method] = (eventHandlers[method] ?? []).filter((h) => h !== handler);
+      };
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe('subscribe retry ladder', () => {
+    it('retries a rejected subscribe at 500ms then 1500ms and settles empty after the third rejection', async () => {
+      vi.useFakeTimers();
+      mockRequest.mockRejectedValue(new Error('subscribe failed'));
+      const { result } = renderHook(() => useGroupMessages('group-1'));
+
+      expect(subscribeCalls()).toHaveLength(1);
+      await act(async () => {
+        await Promise.resolve();
+      });
+      await act(async () => {
+        vi.advanceTimersByTime(499);
+      });
+      expect(subscribeCalls()).toHaveLength(1);
+      await act(async () => {
+        vi.advanceTimersByTime(1);
+        await Promise.resolve();
+      });
+      expect(subscribeCalls()).toHaveLength(2);
+      await act(async () => {
+        vi.advanceTimersByTime(1499);
+      });
+      expect(subscribeCalls()).toHaveLength(2);
+      await act(async () => {
+        vi.advanceTimersByTime(1);
+        await Promise.resolve();
+      });
+      expect(subscribeCalls()).toHaveLength(3);
+      expect(result.current.isLoading).toBe(false);
+      expect(result.current.messages).toEqual([]);
+      await act(async () => {
+        vi.advanceTimersByTime(10000);
+        await Promise.resolve();
+      });
+      expect(subscribeCalls()).toHaveLength(3);
+    });
+
+    it('stops the ladder once an attempt succeeds and then waits indefinitely for the snapshot', async () => {
+      vi.useFakeTimers();
+      mockRequest.mockRejectedValueOnce(new Error('first attempt failed'));
+      const { result } = renderHook(() => useGroupMessages('group-1'));
+
+      await act(async () => {
+        await Promise.resolve();
+      });
+      await act(async () => {
+        vi.advanceTimersByTime(500);
+        await Promise.resolve();
+      });
+      expect(subscribeCalls()).toHaveLength(2);
+      expect(result.current.isLoading).toBe(true);
+      await act(async () => {
+        vi.advanceTimersByTime(20000);
+        await Promise.resolve();
+      });
+      expect(subscribeCalls()).toHaveLength(2);
+      expect(result.current.isLoading).toBe(true);
+
+      const subId = subscribeCalls()[1][1].subscriptionId;
+      act(() => {
+        fireEvent('liveQuery.snapshot', {
+          subscriptionId: subId,
+          rows: [makeMessage(1)],
+          version: 1,
+        });
+      });
+      expect(result.current.messages.map((m) => m.id)).toEqual([1]);
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    it('adopts a late snapshot even after the retry ladder exhausted', async () => {
+      vi.useFakeTimers();
+      mockRequest.mockRejectedValue(new Error('subscribe failed'));
+      const { result } = renderHook(() => useGroupMessages('group-1'));
+      const subId = subscribeCalls()[0][1].subscriptionId;
+
+      await act(async () => {
+        await Promise.resolve();
+      });
+      await act(async () => {
+        vi.advanceTimersByTime(500);
+        await Promise.resolve();
+      });
+      await act(async () => {
+        vi.advanceTimersByTime(1500);
+        await Promise.resolve();
+      });
+      expect(result.current.isLoading).toBe(false);
+
+      act(() => {
+        fireEvent('liveQuery.snapshot', {
+          subscriptionId: subId,
+          rows: [makeMessage(7)],
+          version: 1,
+        });
+      });
+      expect(result.current.messages.map((m) => m.id)).toEqual([7]);
+      expect(result.current.isLoading).toBe(false);
+    });
+  });
+
+  describe('liveQuery.error handling', () => {
+    it('immediately re-requests the same subscription on a delta-phase error and adopts the follow-up snapshot', () => {
+      const { result } = renderHook(() => useGroupMessages('group-1'));
+      const subId = subscribeCalls()[0][1].subscriptionId;
+
+      act(() => {
+        fireEvent('liveQuery.snapshot', {
+          subscriptionId: subId,
+          rows: [makeMessage(1)],
+          version: 1,
+        });
+      });
+      expect(result.current.isLoading).toBe(false);
+
+      act(() => {
+        fireEvent('liveQuery.error', {
+          subscriptionId: subId,
+          code: 'STREAM_LOST',
+          message: 'stream lost',
+          phase: 'delta',
+        });
+      });
+      expect(subscribeCalls()).toHaveLength(2);
+      expect(subscribeCalls()[1][1].subscriptionId).toBe(subId);
+      expect(result.current.messages.map((m) => m.id)).toEqual([1]);
+      expect(result.current.isLoading).toBe(false);
+
+      act(() => {
+        fireEvent('liveQuery.snapshot', {
+          subscriptionId: subId,
+          rows: [makeMessage(1), makeMessage(2)],
+          version: 2,
+        });
+      });
+      expect(result.current.messages.map((m) => m.id)).toEqual([1, 2]);
+    });
+
+    it('leaves the loaded state intact when the resubscribe after a delta-phase error keeps failing', async () => {
+      vi.useFakeTimers();
+      mockRequest.mockResolvedValueOnce({ ok: true }).mockRejectedValue(new Error('down'));
+      const { result } = renderHook(() => useGroupMessages('group-1'));
+      const subId = subscribeCalls()[0][1].subscriptionId;
+
+      act(() => {
+        fireEvent('liveQuery.snapshot', {
+          subscriptionId: subId,
+          rows: [makeMessage(1)],
+          version: 1,
+        });
+      });
+      act(() => {
+        fireEvent('liveQuery.error', {
+          subscriptionId: subId,
+          code: 'STREAM_LOST',
+          message: 'stream lost',
+          phase: 'delta',
+        });
+      });
+      await act(async () => {
+        vi.advanceTimersByTime(5000);
+        await Promise.resolve();
+      });
+      expect(result.current.messages.map((m) => m.id)).toEqual([1]);
+      expect(result.current.isLoading).toBe(false);
+      expect(result.current.isReconnecting).toBe(false);
+    });
+
+    it('releases loading on a snapshot-phase error and still adopts a later snapshot', () => {
+      const { result } = renderHook(() => useGroupMessages('group-1'));
+      const subId = subscribeCalls()[0][1].subscriptionId;
+
+      act(() => {
+        fireEvent('liveQuery.error', {
+          subscriptionId: subId,
+          code: 'QUERY_FAILED',
+          message: 'query failed',
+          phase: 'snapshot',
+        });
+      });
+      expect(result.current.isLoading).toBe(false);
+      expect(result.current.messages).toEqual([]);
+
+      act(() => {
+        fireEvent('liveQuery.snapshot', {
+          subscriptionId: subId,
+          rows: [makeMessage(3)],
+          version: 1,
+        });
+      });
+      expect(result.current.messages.map((m) => m.id)).toEqual([3]);
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    it('retains loaded rows on a snapshot-phase error after loading', () => {
+      const { result } = renderHook(() => useGroupMessages('group-1'));
+      const subId = subscribeCalls()[0][1].subscriptionId;
+
+      act(() => {
+        fireEvent('liveQuery.snapshot', {
+          subscriptionId: subId,
+          rows: [makeMessage(1)],
+          version: 1,
+        });
+      });
+      act(() => {
+        fireEvent('liveQuery.error', {
+          subscriptionId: subId,
+          code: 'QUERY_FAILED',
+          message: 'query failed',
+          phase: 'snapshot',
+        });
+      });
+      expect(result.current.messages.map((m) => m.id)).toEqual([1]);
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    it('ignores liveQuery.error events for a stale subscriptionId', () => {
+      const { result } = renderHook(() => useGroupMessages('group-1'));
+
+      act(() => {
+        fireEvent('liveQuery.error', {
+          subscriptionId: 'stale-error-sub-9999',
+          code: 'STREAM_LOST',
+          message: 'stream lost',
+          phase: 'delta',
+        });
+      });
+      expect(subscribeCalls()).toHaveLength(1);
+      expect(result.current.isLoading).toBe(true);
+    });
+  });
+
+  describe('reconnect', () => {
+    it('resets with a fresh subscriptionId across a disconnect/connect flip and drops the old stream', () => {
+      const { result, rerender } = renderHook(
+        ({ isConn }: { isConn: boolean }) => {
+          mockIsConnected.value = isConn;
+          return useGroupMessages('group-1');
+        },
+        { initialProps: { isConn: true } }
+      );
+      const firstSubId = subscribeCalls()[0][1].subscriptionId;
+
+      act(() => {
+        fireEvent('liveQuery.snapshot', {
+          subscriptionId: firstSubId,
+          rows: [makeMessage(1)],
+          version: 1,
+        });
+      });
+      expect(result.current.messages).toHaveLength(1);
+
+      act(() => {
+        rerender({ isConn: false });
+      });
+      expect(result.current.isReconnecting).toBe(true);
+      expect(result.current.messages).toEqual([]);
+
+      act(() => {
+        rerender({ isConn: true });
+      });
+      expect(result.current.isLoading).toBe(true);
+      expect(subscribeCalls()).toHaveLength(2);
+      const reconnectSubId = subscribeCalls()[1][1].subscriptionId;
+      expect(reconnectSubId).not.toBe(firstSubId);
+
+      act(() => {
+        fireEvent('liveQuery.delta', {
+          subscriptionId: firstSubId,
+          added: [makeMessage(99)],
+          version: 2,
+        });
+      });
+      expect(result.current.messages).toEqual([]);
+    });
+  });
+
+  describe('listener registration and cleanup', () => {
+    it('registers exactly the snapshot, delta, and error listeners', () => {
+      renderHook(() => useGroupMessages('group-1'));
+      expect(mockOnEvent.mock.calls.map((call) => call[0])).toEqual([
+        'liveQuery.snapshot',
+        'liveQuery.delta',
+        'liveQuery.error',
+      ]);
+    });
+
+    it('unsubscribes on unmount and stays inert afterwards', async () => {
+      vi.useFakeTimers();
+      mockRequest.mockRejectedValue(new Error('subscribe failed'));
+      const { unmount } = renderHook(() => useGroupMessages('group-1'));
+      const subId = subscribeCalls()[0][1].subscriptionId;
+
+      await act(async () => {
+        await Promise.resolve();
+      });
+      unmount();
+      expect(unsubscribeCalls()).toEqual([['liveQuery.unsubscribe', { subscriptionId: subId }]]);
+
+      await act(async () => {
+        vi.advanceTimersByTime(10000);
+        await Promise.resolve();
+      });
+      expect(subscribeCalls()).toHaveLength(1);
+
+      fireEvent('liveQuery.snapshot', {
+        subscriptionId: subId,
+        rows: [makeMessage(1) as SessionGroupMessage],
+        version: 2,
+      });
+      fireEvent('liveQuery.delta', {
+        subscriptionId: subId,
+        added: [makeMessage(2)],
+        version: 3,
+      });
+      fireEvent('liveQuery.error', {
+        subscriptionId: subId,
+        code: 'STREAM_LOST',
+        message: 'late',
+        phase: 'delta',
+      });
+      expect(subscribeCalls()).toHaveLength(1);
+    });
+  });
+});

--- a/packages/web/src/hooks/__tests__/useGroupMessages.lifecycle.test.ts
+++ b/packages/web/src/hooks/__tests__/useGroupMessages.lifecycle.test.ts
@@ -207,7 +207,7 @@ describe('useGroupMessages liveQuery lifecycle', () => {
       expect(result.current.messages.map((m) => m.id)).toEqual([1, 2]);
     });
 
-    it('leaves the loaded state intact when the resubscribe after a delta-phase error keeps failing', async () => {
+    it('runs the 500/1500 ladder on the resubscribe after a delta-phase error and leaves the loaded state intact when it keeps failing', async () => {
       vi.useFakeTimers();
       mockRequest.mockResolvedValueOnce({ ok: true }).mockRejectedValue(new Error('down'));
       const { result } = renderHook(() => useGroupMessages('group-1'));
@@ -220,6 +220,8 @@ describe('useGroupMessages liveQuery lifecycle', () => {
           version: 1,
         });
       });
+      expect(subscribeCalls()).toHaveLength(1);
+
       act(() => {
         fireEvent('liveQuery.error', {
           subscriptionId: subId,
@@ -228,13 +230,28 @@ describe('useGroupMessages liveQuery lifecycle', () => {
           phase: 'delta',
         });
       });
+      expect(subscribeCalls()).toHaveLength(2);
       await act(async () => {
-        vi.advanceTimersByTime(5000);
         await Promise.resolve();
       });
+      await act(async () => {
+        vi.advanceTimersByTime(500);
+        await Promise.resolve();
+      });
+      expect(subscribeCalls()).toHaveLength(3);
+      await act(async () => {
+        vi.advanceTimersByTime(1500);
+        await Promise.resolve();
+      });
+      expect(subscribeCalls()).toHaveLength(4);
       expect(result.current.messages.map((m) => m.id)).toEqual([1]);
       expect(result.current.isLoading).toBe(false);
       expect(result.current.isReconnecting).toBe(false);
+      await act(async () => {
+        vi.advanceTimersByTime(10000);
+        await Promise.resolve();
+      });
+      expect(subscribeCalls()).toHaveLength(4);
     });
 
     it('releases loading on a snapshot-phase error and still adopts a later snapshot', () => {

--- a/packages/web/src/hooks/useGroupMessages.ts
+++ b/packages/web/src/hooks/useGroupMessages.ts
@@ -1,5 +1,12 @@
 import { useCallback, useEffect, useMemo, useReducer, useRef, useState } from 'preact/hooks';
 import { useMessageHub } from './useMessageHub';
+import {
+  createLiveQueryLifecycleState,
+  type LiveQueryLifecycleEffect,
+  type LiveQueryLifecycleEvent,
+  type LiveQueryLifecycleState,
+  transitionLiveQueryLifecycle,
+} from '../lib/live-query-lifecycle';
 import type {
   LiveQueryDeltaEvent,
   LiveQueryErrorEvent,
@@ -163,6 +170,10 @@ const INITIAL_PAGINATION_STATE: PaginationState = {
   hiddenTopLevelCount: 0,
 };
 
+const RETRY_DELAYS_MS: [number, number] = [500, 1500];
+
+type LifecycleStorePayload = LiveQuerySnapshotEvent | LiveQueryDeltaEvent | null;
+
 let _subscriptionCounter = 0;
 
 export function generateGroupMessagesSubId(groupId: string): string {
@@ -183,7 +194,7 @@ export function useGroupMessages(
 
   const { request, onEvent, isConnected } = useMessageHub();
 
-  const [{ allMessages, hiddenOlderCount, hiddenTopLevelCount }, dispatch] = useReducer(
+  const [{ allMessages, hiddenOlderCount, hiddenTopLevelCount }, dispatchPagination] = useReducer(
     paginationReducer,
     INITIAL_PAGINATION_STATE
   );
@@ -193,7 +204,7 @@ export function useGroupMessages(
 
   useEffect(() => {
     if (!groupId || !isConnected) {
-      dispatch({ type: 'reset' });
+      dispatchPagination({ type: 'reset' });
       setLoadedForGroupId(null);
       activeSubIdRef.current = null;
       return;
@@ -201,77 +212,118 @@ export function useGroupMessages(
 
     const subscriptionId = generateGroupMessagesSubId(groupId);
     activeSubIdRef.current = subscriptionId;
-    dispatch({ type: 'reset' });
+    dispatchPagination({ type: 'reset' });
     setLoadedForGroupId(null);
 
-    const unsubSnapshot = onEvent<LiveQuerySnapshotEvent>('liveQuery.snapshot', (event) => {
-      if (event.subscriptionId !== activeSubIdRef.current) return;
-      dispatch({
-        type: 'snapshot',
-        rows: event.rows as SessionGroupMessage[],
-        pageSize: pageSizeRef.current,
-      });
-      setLoadedForGroupId(groupId);
-    });
+    const initial = createLiveQueryLifecycleState({ snapshotRetryEnabled: false });
+    let lifecycle: LiveQueryLifecycleState = initial.state;
+    const retryTimers = new Set<ReturnType<typeof setTimeout>>();
 
-    const unsubDelta = onEvent<LiveQueryDeltaEvent>('liveQuery.delta', (event) => {
-      if (event.subscriptionId !== activeSubIdRef.current) return;
-      dispatch({
-        type: 'delta',
-        removed: event.removed as SessionGroupMessage[] | undefined,
-        updated: event.updated as SessionGroupMessage[] | undefined,
-        added: event.added as SessionGroupMessage[] | undefined,
-      });
-    });
+    const dispatch = (event: LiveQueryLifecycleEvent): LiveQueryLifecycleEffect[] => {
+      const result = transitionLiveQueryLifecycle(lifecycle, event);
+      lifecycle = result.state;
+      return result.effects;
+    };
 
-    const unsubError = onEvent<LiveQueryErrorEvent>('liveQuery.error', (event) => {
-      if (event.subscriptionId !== activeSubIdRef.current) return;
-      if (event.phase === 'delta') {
+    const requestSubscribe = (generation: number, attempt: number): void => {
+      Promise.resolve(
         request('liveQuery.subscribe', {
           queryName: 'sessionGroupMessages.byGroup',
           params: [groupId],
           subscriptionId,
-        }).catch(() => setLoadedForGroupId(groupId));
-        return;
-      }
-      setLoadedForGroupId(groupId);
-    });
-
-    const MAX_RETRIES = 2;
-    const RETRY_DELAYS_MS: [number, number] = [500, 1500];
-
-    let retryTimer: ReturnType<typeof setTimeout> | null = null;
-
-    const subscribeWithRetry = (attempt: number): void => {
-      request('liveQuery.subscribe', {
-        queryName: 'sessionGroupMessages.byGroup',
-        params: [groupId],
-        subscriptionId,
-      }).catch(() => {
-        if (activeSubIdRef.current !== subscriptionId) return;
-        if (attempt < MAX_RETRIES) {
-          retryTimer = setTimeout(() => {
-            retryTimer = null;
-            if (activeSubIdRef.current === subscriptionId) {
-              subscribeWithRetry(attempt + 1);
-            }
-          }, RETRY_DELAYS_MS[attempt]);
-        } else {
-          if (activeSubIdRef.current === subscriptionId) {
-            setLoadedForGroupId(groupId);
+        })
+      )
+        .then(() => {
+          executeEffects(dispatch({ type: 'subscribed', generation }));
+        })
+        .catch(() => {
+          if (activeSubIdRef.current !== subscriptionId) return;
+          if (attempt >= RETRY_DELAYS_MS.length) {
+            executeEffects(dispatch({ type: 'snapshot-failed', generation }));
+            return;
           }
-        }
-      });
+          const timer = setTimeout(() => {
+            retryTimers.delete(timer);
+            if (activeSubIdRef.current !== subscriptionId) return;
+            requestSubscribe(generation, attempt + 1);
+          }, RETRY_DELAYS_MS[attempt]);
+          retryTimers.add(timer);
+        });
     };
 
-    subscribeWithRetry(0);
+    const executeEffects = (
+      effects: LiveQueryLifecycleEffect[],
+      payload: LifecycleStorePayload = null
+    ): void => {
+      for (const effect of effects) {
+        if (effect.kind === 're-snapshot') {
+          requestSubscribe(effect.generation, 0);
+          continue;
+        }
+        if (effect.kind === 'schedule-cleanup') {
+          for (const timer of retryTimers) clearTimeout(timer);
+          retryTimers.clear();
+          continue;
+        }
+        if (effect.kind !== 'emit-to-store') continue;
+        if (effect.emission.type === 'snapshot') {
+          const snapshot = payload as LiveQuerySnapshotEvent | null;
+          dispatchPagination({
+            type: 'snapshot',
+            rows: (snapshot?.rows as SessionGroupMessage[]) ?? [],
+            pageSize: pageSizeRef.current,
+          });
+          setLoadedForGroupId(groupId);
+          continue;
+        }
+        if (effect.emission.type === 'delta') {
+          const delta = payload as LiveQueryDeltaEvent | null;
+          if (delta) {
+            dispatchPagination({
+              type: 'delta',
+              removed: delta.removed as SessionGroupMessage[] | undefined,
+              updated: delta.updated as SessionGroupMessage[] | undefined,
+              added: delta.added as SessionGroupMessage[] | undefined,
+            });
+          }
+          continue;
+        }
+        setLoadedForGroupId(groupId);
+      }
+    };
+
+    executeEffects(initial.effects);
+
+    const unsubSnapshot = onEvent<LiveQuerySnapshotEvent>('liveQuery.snapshot', (event) => {
+      if (event.subscriptionId !== subscriptionId) return;
+      executeEffects(
+        dispatch({ type: 'snapshot-arrived', generation: lifecycle.generation }),
+        event
+      );
+    });
+
+    const unsubDelta = onEvent<LiveQueryDeltaEvent>('liveQuery.delta', (event) => {
+      if (event.subscriptionId !== subscriptionId) return;
+      executeEffects(dispatch({ type: 'delta-arrived', generation: lifecycle.generation }), event);
+    });
+
+    const unsubError = onEvent<LiveQueryErrorEvent>('liveQuery.error', (event) => {
+      if (event.subscriptionId !== subscriptionId) return;
+      if (event.phase === 'delta') {
+        executeEffects(dispatch({ type: 'transport-error', generation: lifecycle.generation }));
+        return;
+      }
+      executeEffects(
+        dispatch({
+          type: 'snapshot-failed',
+          generation: lifecycle.generation,
+          message: event.message,
+        })
+      );
+    });
 
     return () => {
-      if (retryTimer !== null) {
-        clearTimeout(retryTimer);
-        retryTimer = null;
-      }
-
+      executeEffects(dispatch({ type: 'unsubscribe' }));
       unsubSnapshot();
       unsubDelta();
       unsubError();
@@ -288,7 +340,7 @@ export function useGroupMessages(
   );
 
   const loadEarlier = useCallback(() => {
-    dispatch({ type: 'loadEarlier', pageSize: pageSizeRef.current });
+    dispatchPagination({ type: 'loadEarlier', pageSize: pageSizeRef.current });
   }, []);
 
   const isLoading = groupId !== null && isConnected && loadedForGroupId !== groupId;


### PR DESCRIPTION
## Summary

UI Pilot 6 PR 5. Pins then migrates the last hand-rolled hook lifecycle copy, `useGroupMessages`, onto the shared `live-query-lifecycle` machine. The adjacent `paginationReducer` machinery is untouched.

- **Pins first** (`useGroupMessages.lifecycle.test.ts`, 11 tests, written against and passing on the pre-migration hook): subscribe retry ladder (retries at 500ms/1500ms, settles empty after the 3rd rejection, adopts a late snapshot after exhaustion), no snapshot watchdog after a successful subscribe, delta-phase error → immediate same-subscriptionId re-request + follow-up snapshot adoption, snapshot-phase error → loading released with late-snapshot revival, stale-subscriptionId errors ignored, reconnect reset via the `isConnected` dep with a fresh subscriptionId, exact listener set (`snapshot`/`delta`/`error` — no connection listener), unmount inertness.
- **Migration**: the effect now drives `createLiveQueryLifecycleState({ snapshotRetryEnabled: false })` through `dispatch`/`executeEffects` like its siblings. The 500/1500ms retry-on-rejected-subscribe ladder stays an executor concern inside the `re-snapshot` handler (the machine has no request-failure event; its only retry machinery is the post-`subscribed` snapshot watchdog, which this hook must not have). `liveQuery.error` maps to `transport-error` (delta phase) / `snapshot-failed` with message (snapshot phase); cleanup rides the machine's `unsubscribe` → `schedule-cleanup` for the retry timers.
- All 11 pins and the 46 pre-existing `useGroupMessages` tests pass unchanged; full web suite green (7175 passed).

**Known window-tightening (consistent with PR 3/4 precedent)**: deltas arriving before the first snapshot or during a resubscribe window are now gated by the machine's `live` state instead of merging unconditionally; the resubscribe that follows re-establishes via a full snapshot, so end state is unchanged.

## Store-level variants assessment (report-only, no changes)

- **`app-mcp-store.ts` — fits as-is.** Single fixed subscription, explicit `subscribe()`/`unsubscribe()`, snapshot/delta/error listeners, `onConnection` resubscribe, real error+loading signals. Maps 1:1 onto the machine with `snapshotRetryEnabled: false`; settle-with-error ≈ its `error.value` + `loading=false`. Best first store consumer for PR 6.
- **`global-store.ts` — fits with one small machine extension (or legitimately stays hand-rolled).** Its `sessions.list` subscription has *dynamic params* (`showArchived` toggle re-subscribes under the same stable id); the machine has no "params-changed, same subscription" event — that would need a `resubscribe`-style extension, or the executor reads current params at effect time. It also swallows all errors (`.catch(() => {})`) and has no loading surface, so the machine's `error-retry`/`settled-empty` states carry no UI meaning here.
- **`space-store.ts` — fits with machine extensions + a store adapter; highest payoff.** Four near-identical hand-rolled blocks (`spaceTaskActivity.byTask`, `spaceTaskMessages.byTask.compact`, `nodeExecutions.byRun` ×N concurrent, `spaceSessions.bySpace`). Block-level lifecycle is the same copy-paste shape a shared executor would collapse. Differences the machine doesn't cover today: (1) no `liveQuery.error` listeners anywhere — server-side query errors are invisible, so migrating would *add* behavior needing an error-policy decision (ignore emissions vs. add signals); (2) `nodeExecutions` runs N concurrent subscriptions merged into one signal — one machine instance per subscriptionId with emission-side merges; (3) `subscribeTaskActivity`/`subscribeTaskMessageActivity` are awaited and *throw* on initial failure (callers rely on rejection), while the machine settles via emissions — needs an async bridge; (4) fire-and-forget reconnect resubscribes with no retry/settle — maps to `transport-error` + `snapshotRetryEnabled: false` + an executor that only logs settle emissions.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/lsm/hyperneo/pull/2788" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

## Assessment corrections from round-1 review

- **`space-store.ts` correction**: `nodeExecutions.byRun` is **single-active in practice** — `ensureNodeExecutions` (`space-store.ts:1299`) calls `unsubscribeNodeExecutions()` (clearing every run subscription and the active-id Set) before subscribing to a new run, despite the `Set` bookkeeping suggesting N concurrent subscriptions. The multi-instance machine concern is therefore weaker than stated; one machine instance at a time suffices.
- **Un-assessed variants PR 6 should inventory**: `space-mcp-store.ts`, `skills-store.ts`, and `session-store.ts`'s `messages.bySession` subscription were outside this task's scope and are not covered by the three-store assessment above.
