### PR TITLE
refactor(daemon): extract delivery-status routing table (chain C PR 3/5)

### DIFF
--- a/packages/daemon/src/storage/repositories/delivery-status-routing.ts
+++ b/packages/daemon/src/storage/repositories/delivery-status-routing.ts
@@ -1,0 +1,47 @@
+import type { SendStatus } from './sdk-message-admission';
+
+export type DeliveryTransitionAction =
+  | 'fail'
+  | 'fail_inclusive'
+  | 'consume'
+  | 'submit'
+  | 'reopen'
+  | 'retry'
+  | 'defer';
+
+interface DeliveryTransitionRule {
+  acceptedFrom: readonly SendStatus[];
+  target: SendStatus;
+}
+
+const DELIVERY_TRANSITION_RULES: Readonly<
+  Record<DeliveryTransitionAction, DeliveryTransitionRule>
+> = {
+  fail: { acceptedFrom: ['enqueued', 'deferred', 'submitted'], target: 'failed' },
+  fail_inclusive: { acceptedFrom: ['enqueued', 'submitted', 'consumed'], target: 'failed' },
+  consume: { acceptedFrom: ['enqueued', 'submitted'], target: 'consumed' },
+  submit: { acceptedFrom: ['enqueued'], target: 'submitted' },
+  reopen: { acceptedFrom: ['failed'], target: 'enqueued' },
+  retry: { acceptedFrom: ['consumed'], target: 'enqueued' },
+  defer: { acceptedFrom: ['enqueued'], target: 'deferred' },
+};
+
+export interface DeliveryTransitionRouting {
+  accepted: boolean;
+  targetStatus: SendStatus;
+}
+
+export function routeDeliveryTransition(
+  currentStatus: string | null | undefined,
+  action: DeliveryTransitionAction
+): DeliveryTransitionRouting {
+  const rule = DELIVERY_TRANSITION_RULES[action];
+  return {
+    accepted: rule.acceptedFrom.includes(currentStatus as SendStatus),
+    targetStatus: rule.target,
+  };
+}
+
+export function deliveryTransitionRule(action: DeliveryTransitionAction): DeliveryTransitionRule {
+  return DELIVERY_TRANSITION_RULES[action];
+}

--- a/packages/daemon/src/storage/repositories/sdk-message-repository.ts
+++ b/packages/daemon/src/storage/repositories/sdk-message-repository.ts
@@ -1,25 +1,14 @@
-import type { Database as BunDatabase } from '../sqlite-compat';
-import { generateUUID } from '@hyperneo/shared';
 import type {
+  ChatMessage,
+  HyperNeoActionMessage,
   MessageContent,
   MessageDeliveryStatus,
   MessageOrigin,
-  HyperNeoActionMessage,
-  ChatMessage,
 } from '@hyperneo/shared';
+import { generateUUID } from '@hyperneo/shared';
 import type { SDKMessage, SDKUserMessage } from '@hyperneo/shared/sdk';
 import { HIDDEN_SYSTEM_SUBTYPES } from '@hyperneo/shared/sdk/type-guards';
-import type { ReactiveDatabase } from '../reactive-database';
 import { Logger } from '../../lib/logger';
-import {
-  inflatePersistedMessage,
-  projectBackgroundTaskMessageRow,
-  projectSubagentMessageRow,
-  projectTopLevelMessageRow,
-  type BackgroundTaskMessageRow,
-  type PaginationMessageRow,
-  type SubagentMessageRow,
-} from './sdk-message-projections';
 import {
   buildFtsQuery,
   extractVisibleSearchText,
@@ -28,7 +17,15 @@ import {
   type MessageSearchResponse,
   type MessageSearchResult,
 } from '../message-search';
+import type { ReactiveDatabase } from '../reactive-database';
+import type { Database as BunDatabase } from '../sqlite-compat';
 import type { SQLiteValue } from '../types';
+import {
+  type DeliveryTransitionAction,
+  deliveryTransitionRule,
+  routeDeliveryTransition,
+} from './delivery-status-routing';
+import { decideMessageSearchAdmission } from './message-search-admission';
 import {
   decideMessageAdmission,
   extractReplacementEdges,
@@ -36,16 +33,24 @@ import {
   type SDKMessageReplacementEdge,
   type SendStatus,
 } from './sdk-message-admission';
-import { decideMessageSearchAdmission } from './message-search-admission';
+import {
+  type BackgroundTaskMessageRow,
+  inflatePersistedMessage,
+  type PaginationMessageRow,
+  projectBackgroundTaskMessageRow,
+  projectSubagentMessageRow,
+  projectTopLevelMessageRow,
+  type SubagentMessageRow,
+} from './sdk-message-projections';
 
+export type { SDKMessageReplacementEdge, SendStatus } from './sdk-message-admission';
 export {
   computeIsRenderable,
   computeIsTerminal,
   extractParentToolUseId,
-  extractSdkUuid,
   extractReplacementEdges,
+  extractSdkUuid,
 } from './sdk-message-admission';
-export type { SDKMessageReplacementEdge, SendStatus } from './sdk-message-admission';
 
 const RENDERABLE_TEXT_MESSAGE_BATCH_SIZE = 50;
 const RENDERABLE_TEXT_MESSAGE_MAX_SCAN = 250;
@@ -1220,19 +1225,23 @@ export class SDKMessageRepository {
   ): { dbId: string; uuid: string } | null {
     const row = this.db
       .prepare(
-        `SELECT id, sdk_message FROM sdk_messages
+        `SELECT id, sdk_message, send_status FROM sdk_messages
           WHERE session_id = ? AND id = ? AND message_type = 'user'
-            AND send_status = 'enqueued' LIMIT 1`
+          LIMIT 1`
       )
-      .get(sessionId, messageId) as { id: string; sdk_message: string } | undefined;
+      .get(sessionId, messageId) as
+      | { id: string; sdk_message: string; send_status: string | null }
+      | undefined;
     if (!row) return null;
+    const routing = routeDeliveryTransition(row.send_status, 'defer');
+    if (!routing.accepted) return null;
     const changed = this.db
       .prepare(
-        `UPDATE sdk_messages SET send_status = 'deferred'
+        `UPDATE sdk_messages SET send_status = ?
           WHERE session_id = ? AND id = ? AND message_type = 'user'
-            AND send_status = 'enqueued'`
+            AND send_status = ?`
       )
-      .run(sessionId, messageId).changes;
+      .run(routing.targetStatus, sessionId, messageId, row.send_status).changes;
     if (changed === 0) return null;
     const message = JSON.parse(row.sdk_message) as { uuid?: string };
     return { dbId: row.id, uuid: message.uuid ?? '' };
@@ -1511,46 +1520,35 @@ export class SDKMessageRepository {
       .run(sessionId, messageUuid);
   }
 
-  markDeliveryFailedByUuid(sessionId: string, uuid: string): string | null {
+  private markDeliveryTransitionByUuid(
+    sessionId: string,
+    uuid: string,
+    action: DeliveryTransitionAction
+  ): string | null {
+    const { acceptedFrom, target } = deliveryTransitionRule(action);
     const row = this.db
       .prepare(
         `SELECT id FROM sdk_messages
            WHERE session_id = ? AND message_type = 'user' AND sdk_uuid = ?
-             AND send_status IN ('enqueued', 'deferred', 'submitted')
+             AND send_status IN (${acceptedFrom.map(() => '?').join(', ')})
            ORDER BY timestamp ASC LIMIT 1`
       )
-      .get(sessionId, uuid) as { id: string } | undefined;
+      .get(sessionId, uuid, ...acceptedFrom) as { id: string } | undefined;
     if (!row) return null;
-    this.updateMessageStatus([row.id], 'failed');
+    this.updateMessageStatus([row.id], target);
     return row.id;
+  }
+
+  markDeliveryFailedByUuid(sessionId: string, uuid: string): string | null {
+    return this.markDeliveryTransitionByUuid(sessionId, uuid, 'fail');
   }
 
   markDeliveryFailedByUuidInclusive(sessionId: string, uuid: string): string | null {
-    const row = this.db
-      .prepare(
-        `SELECT id FROM sdk_messages
-           WHERE session_id = ? AND message_type = 'user' AND sdk_uuid = ?
-             AND send_status IN ('enqueued', 'submitted', 'consumed')
-           ORDER BY timestamp ASC LIMIT 1`
-      )
-      .get(sessionId, uuid) as { id: string } | undefined;
-    if (!row) return null;
-    this.updateMessageStatus([row.id], 'failed');
-    return row.id;
+    return this.markDeliveryTransitionByUuid(sessionId, uuid, 'fail_inclusive');
   }
 
   markDeliveryConsumedByUuid(sessionId: string, uuid: string): string | null {
-    const row = this.db
-      .prepare(
-        `SELECT id FROM sdk_messages
-           WHERE session_id = ? AND message_type = 'user' AND sdk_uuid = ?
-             AND send_status IN ('enqueued', 'submitted')
-           ORDER BY timestamp ASC LIMIT 1`
-      )
-      .get(sessionId, uuid) as { id: string } | undefined;
-    if (!row) return null;
-    this.updateMessageStatus([row.id], 'consumed');
-    return row.id;
+    return this.markDeliveryTransitionByUuid(sessionId, uuid, 'consume');
   }
 
   markDeliveryConsumedAtTurnEnd(
@@ -1577,6 +1575,7 @@ export class SDKMessageRepository {
         )
         .get(sessionId, resultUuid) as { consumed_seq: number } | undefined;
       if (!result) return { ids: [], uuids: [] };
+      const { acceptedFrom, target } = deliveryTransitionRule('consume');
       const ids: string[] = [];
       const consumedUuids: string[] = [];
       for (const [index, uuid] of [...new Set(uuids)].entries()) {
@@ -1584,17 +1583,17 @@ export class SDKMessageRepository {
           .prepare(
             `SELECT id FROM sdk_messages
                WHERE session_id = ? AND message_type = 'user' AND sdk_uuid = ?
-                 AND send_status IN ('enqueued', 'submitted')
+                 AND send_status IN (${acceptedFrom.map(() => '?').join(', ')})
                ORDER BY timestamp ASC LIMIT 1`
           )
-          .get(sessionId, uuid) as { id: string } | undefined;
+          .get(sessionId, uuid, ...acceptedFrom) as { id: string } | undefined;
         if (index === 0 && !row) return { ids: [], uuids: [] };
         if (row) {
           ids.push(row.id);
           consumedUuids.push(uuid);
         }
       }
-      this.updateMessageStatus(ids, 'consumed', {
+      this.updateMessageStatus(ids, target, {
         sharedTurn: true,
         consumedSeq: result.consumed_seq,
       });
@@ -1604,37 +1603,39 @@ export class SDKMessageRepository {
 
   markDeliveryConsumedByUuids(sessionId: string, uuids: string[]): string[] {
     return this.db.transaction(() => {
+      const { acceptedFrom, target } = deliveryTransitionRule('consume');
       const ids: string[] = [];
       for (const uuid of new Set(uuids)) {
         const row = this.db
           .prepare(
             `SELECT id FROM sdk_messages
                WHERE session_id = ? AND message_type = 'user' AND sdk_uuid = ?
-                 AND send_status IN ('enqueued', 'submitted')
+                 AND send_status IN (${acceptedFrom.map(() => '?').join(', ')})
                ORDER BY timestamp ASC LIMIT 1`
           )
-          .get(sessionId, uuid) as { id: string } | undefined;
+          .get(sessionId, uuid, ...acceptedFrom) as { id: string } | undefined;
         if (row) ids.push(row.id);
       }
-      this.updateMessageStatus(ids, 'consumed', { sharedTurn: true });
+      this.updateMessageStatus(ids, target, { sharedTurn: true });
       return ids;
     })();
   }
 
   markDeliverySubmittedByUuids(sessionId: string, uuids: string[]): string[] {
     return this.db.transaction(() => {
+      const { acceptedFrom, target } = deliveryTransitionRule('submit');
       const ids: string[] = [];
       for (const uuid of new Set(uuids)) {
         const row = this.db
           .prepare(
             `SELECT id FROM sdk_messages
                WHERE session_id = ? AND message_type = 'user' AND sdk_uuid = ?
-                 AND send_status = 'enqueued'
+                 AND send_status IN (${acceptedFrom.map(() => '?').join(', ')})
                ORDER BY timestamp ASC LIMIT 1`
           )
-          .get(sessionId, uuid) as { id: string } | undefined;
+          .get(sessionId, uuid, ...acceptedFrom) as { id: string } | undefined;
         if (!row) continue;
-        this.updateMessageStatus([row.id], 'submitted');
+        this.updateMessageStatus([row.id], target);
         ids.push(row.id);
       }
       return ids;
@@ -1642,45 +1643,15 @@ export class SDKMessageRepository {
   }
 
   reopenDeliveryByUuid(sessionId: string, uuid: string): string | null {
-    const row = this.db
-      .prepare(
-        `SELECT id FROM sdk_messages
-           WHERE session_id = ? AND message_type = 'user' AND sdk_uuid = ?
-             AND send_status = 'failed'
-           ORDER BY timestamp ASC LIMIT 1`
-      )
-      .get(sessionId, uuid) as { id: string } | undefined;
-    if (!row) return null;
-    this.updateMessageStatus([row.id], 'enqueued');
-    return row.id;
+    return this.markDeliveryTransitionByUuid(sessionId, uuid, 'reopen');
   }
 
   markDeliveryRetryableByUuid(sessionId: string, uuid: string): string | null {
-    const row = this.db
-      .prepare(
-        `SELECT id FROM sdk_messages
-           WHERE session_id = ? AND message_type = 'user' AND sdk_uuid = ?
-             AND send_status = 'consumed'
-           ORDER BY timestamp ASC LIMIT 1`
-      )
-      .get(sessionId, uuid) as { id: string } | undefined;
-    if (!row) return null;
-    this.updateMessageStatus([row.id], 'enqueued');
-    return row.id;
+    return this.markDeliveryTransitionByUuid(sessionId, uuid, 'retry');
   }
 
   markDeliveryDeferredByUuid(sessionId: string, uuid: string): string | null {
-    const row = this.db
-      .prepare(
-        `SELECT id FROM sdk_messages
-           WHERE session_id = ? AND message_type = 'user' AND sdk_uuid = ?
-             AND send_status = 'enqueued'
-           ORDER BY timestamp ASC LIMIT 1`
-      )
-      .get(sessionId, uuid) as { id: string } | undefined;
-    if (!row) return null;
-    this.updateMessageStatus([row.id], 'deferred');
-    return row.id;
+    return this.markDeliveryTransitionByUuid(sessionId, uuid, 'defer');
   }
 
   private parseUserMessageRow(

--- a/packages/daemon/tests/unit/4-space-storage/storage/delivery-status-routing.test.ts
+++ b/packages/daemon/tests/unit/4-space-storage/storage/delivery-status-routing.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  type DeliveryTransitionAction,
+  deliveryTransitionRule,
+  routeDeliveryTransition,
+} from '../../../../src/storage/repositories/delivery-status-routing';
+import type { SendStatus } from '../../../../src/storage/repositories/sdk-message-admission';
+
+const ALL_STATUSES = ['deferred', 'enqueued', 'submitted', 'consumed', 'failed'] as const;
+
+const ACTIONS: ReadonlyArray<{
+  action: DeliveryTransitionAction;
+  wrappers: readonly string[];
+  acceptedFrom: readonly SendStatus[];
+  target: SendStatus;
+}> = [
+  {
+    action: 'fail',
+    wrappers: ['markDeliveryFailedByUuid'],
+    acceptedFrom: ['enqueued', 'deferred', 'submitted'],
+    target: 'failed',
+  },
+  {
+    action: 'fail_inclusive',
+    wrappers: ['markDeliveryFailedByUuidInclusive'],
+    acceptedFrom: ['enqueued', 'submitted', 'consumed'],
+    target: 'failed',
+  },
+  {
+    action: 'consume',
+    wrappers: [
+      'markDeliveryConsumedByUuid',
+      'markDeliveryConsumedAtTurnEnd',
+      'markDeliveriesConsumedAtTurnEnd',
+      'markDeliveryConsumedByUuids',
+    ],
+    acceptedFrom: ['enqueued', 'submitted'],
+    target: 'consumed',
+  },
+  {
+    action: 'submit',
+    wrappers: ['markDeliverySubmittedByUuids'],
+    acceptedFrom: ['enqueued'],
+    target: 'submitted',
+  },
+  {
+    action: 'reopen',
+    wrappers: ['reopenDeliveryByUuid'],
+    acceptedFrom: ['failed'],
+    target: 'enqueued',
+  },
+  {
+    action: 'retry',
+    wrappers: ['markDeliveryRetryableByUuid'],
+    acceptedFrom: ['consumed'],
+    target: 'enqueued',
+  },
+  {
+    action: 'defer',
+    wrappers: ['markDeliveryDeferredByUuid', 'deferEnqueuedUserMessage'],
+    acceptedFrom: ['enqueued'],
+    target: 'deferred',
+  },
+];
+
+describe('routeDeliveryTransition', () => {
+  for (const { action, wrappers, acceptedFrom, target } of ACTIONS) {
+    test(`${action} (${wrappers.join(', ')}): ${acceptedFrom.join('/')} → ${target}; every other from-status routes unaccepted`, () => {
+      for (const status of ALL_STATUSES) {
+        expect(routeDeliveryTransition(status, action)).toEqual({
+          accepted: acceptedFrom.includes(status),
+          targetStatus: target,
+        });
+      }
+    });
+  }
+
+  test('treats null, empty, unknown, and case-mismatched statuses as unaccepted for every action', () => {
+    for (const status of [null, undefined, '', 'migrated', 'ENQUEUED', 'queued'] as Array<
+      string | null | undefined
+    >) {
+      for (const { action, target } of ACTIONS) {
+        expect(routeDeliveryTransition(status, action)).toEqual({
+          accepted: false,
+          targetStatus: target,
+        });
+      }
+    }
+  });
+});
+
+describe('deliveryTransitionRule', () => {
+  test('exposes the shared window and target each wrapper parameterizes its lookup and update from', () => {
+    for (const { action, acceptedFrom, target } of ACTIONS) {
+      expect(deliveryTransitionRule(action)).toEqual({ acceptedFrom, target });
+    }
+  });
+});


### PR DESCRIPTION
Collapses the ten uuid-keyed markDelivery*/reopenDelivery wrappers' status windows into a shared routing table (delivery-status-routing.ts): routeDeliveryTransition(currentStatus, action) decides accepted-window + target, and deliveryTransitionRule exposes the window/target the repository parameterizes its SQL IN clauses from. Six single-uuid wrappers now share one private markDeliveryTransitionByUuid helper; the bulk consume/submit loops and the turn-end batch keep their per-uuid skip vs first-uuid all-or-nothing semantics and the result prerequisite, unchanged. deferEnqueuedUserMessage keeps its dbId-keyed lookup and {dbId, uuid} return shape but routes its enqueued→deferred decision through the table. A pure matrix test pins all 5 statuses × 7 actions; the C1 repository window-matrix tests remain the parity harness, untouched.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/lsm/hyperneo/pull/2791" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->