### PR TITLE
fix(daemon): harden ACP query abort and interrupt semantics

### DIFF
--- a/packages/daemon/src/lib/acp/acp-query-runner.ts
+++ b/packages/daemon/src/lib/acp/acp-query-runner.ts
@@ -58,6 +58,8 @@ import { AcpMcpProxyBridge, shouldProxy } from './mcp-proxy-bridge';
 const DEFAULT_STARTUP_TIMEOUT_MS = 15000;
 const RETRY_EXIT_TIMEOUT_MS = 5000;
 const MAX_FS_READ_BYTES = 4 * 1024 * 1024;
+const MAX_POST_ABORT_DRAIN_MESSAGES = 256;
+const POST_ABORT_DRAIN_TIMEOUT_MS = 1000;
 
 function getStartupTimeoutMs(): number {
   const raw = process.env.HYPERNEO_SDK_STARTUP_TIMEOUT_MS;
@@ -299,6 +301,23 @@ async function allowAcpPermissionRequest(
   return { outcome: { outcome: 'selected', optionId: option.optionId } };
 }
 
+function isAcpToolResultMessage(message: SDKMessage): boolean {
+  return message.type === 'user' && (message as SDKUserMessage).parent_tool_use_id != null;
+}
+
+function isAcpToolUseMessage(message: SDKMessage): boolean {
+  if (message.type !== 'assistant') return false;
+  const content = (message as { message?: { content?: unknown } }).message?.content;
+  return (
+    Array.isArray(content) &&
+    content.some((block) => (block as { type?: string } | null)?.type === 'tool_use')
+  );
+}
+
+function isAcpPostAbortRelevantMessage(message: SDKMessage): boolean {
+  return isAcpToolResultMessage(message) || isAcpToolUseMessage(message);
+}
+
 function systemPromptText(systemPrompt: Options['systemPrompt']): string[] {
   if (!systemPrompt) return [];
   if (typeof systemPrompt === 'string') return [systemPrompt];
@@ -387,6 +406,17 @@ export class AcpQueryRunner {
     recoveryState = { rateLimitCooldownScheduled: false }
   ): Promise<void> {
     const { session, messageQueue, stateManager, errorManager, logger, optionsBuilder } = this.ctx;
+    const assertActiveAcpStartup = () => {
+      if (
+        this.ctx.isCleaningUp() ||
+        this.ctx.getQueryGeneration() !== queryGeneration ||
+        stateManager.getState().status === 'interrupted'
+      ) {
+        const error = new Error('ACP query aborted during startup');
+        error.name = 'AbortError';
+        throw error;
+      }
+    };
     let client: AcpClient | null = null;
     let queryStartTime = Date.now();
     let startupTimeoutReached = false;
@@ -484,6 +514,7 @@ export class AcpQueryRunner {
       const workspace = getAcpWorkspacePath(session, queryOptions);
       const cwd = workspace ?? process.cwd();
       const startupTimeoutMs = getStartupTimeoutMs();
+      assertActiveAcpStartup();
       const abortController = new AbortController();
       this.ctx.queryAbortController = abortController;
       runAbortController = abortController;
@@ -511,6 +542,12 @@ export class AcpQueryRunner {
                 `(Hint: set HYPERNEO_SDK_STARTUP_TIMEOUT_MS to increase timeout, currently ${startupTimeoutMs}ms)`
             );
             abortController.abort();
+            try {
+              client?.cancel();
+              if (client?.canCloseSession()) {
+                client.closeSession().catch(() => {});
+              }
+            } catch {}
             this.ctx.queryObject?.close();
             client?.close();
           }
@@ -581,6 +618,7 @@ export class AcpQueryRunner {
             };
           })()
         : {};
+      assertActiveAcpStartup();
       client = this.createAcpClient({
         command,
         args,
@@ -593,6 +631,7 @@ export class AcpQueryRunner {
         onPermissionRequest: allowAcpPermissionRequest,
         ...hostCallbacks,
       });
+      assertActiveAcpStartup();
 
       if (messageQueue.size() > 0) {
         startStartupTimer(() => false);
@@ -600,6 +639,7 @@ export class AcpQueryRunner {
 
       await client.initialize();
       await client.authenticate();
+      assertActiveAcpStartup();
       const existingAcpSessionId = session.acpSessionId;
       if (existingAcpSessionId) {
         if (!client.canLoadSession()) {
@@ -647,6 +687,7 @@ export class AcpQueryRunner {
       await this.ctx.onModelsFetched().catch((error) => {
         logger.warn('Background fetch of models failed:', error);
       });
+      assertActiveAcpStartup();
 
       for await (const { message, onSent } of messageQueue.messageGenerator(session.id, {
         suppressPreYieldCallback: true,
@@ -800,6 +841,11 @@ export class AcpQueryRunner {
       proxyBridge = null;
       const isStaleQuery = this.ctx.getQueryGeneration() !== queryGeneration;
 
+      if (isStaleQuery && client) {
+        try {
+          client.close();
+        } catch {}
+      }
       if (!isStaleQuery) {
         this.clearStartupTimer();
 
@@ -847,6 +893,7 @@ export class AcpQueryRunner {
           });
         }
 
+        this._lastConsumedUserMessage = null;
         this.ctx.queryPromise = null;
       }
     }
@@ -897,7 +944,7 @@ export class AcpQueryRunner {
       await stateManager.setIdle({ suppressDeliveryWaiters: true });
 
       if (isStartupTimeout && createdAcpSessionDuringRun && !receivedAcpMessageDuringRun) {
-        this.persistAcpSessionId(undefined);
+        this.clearAcpSessionState();
       }
 
       const lastMsg = this._lastConsumedUserMessage;
@@ -1133,7 +1180,7 @@ export class AcpQueryRunner {
     }
   }
 
-  private persistAcpSessionId(acpSessionId: string | undefined): void {
+  private persistAcpSessionId(acpSessionId: string): void {
     const { session, db } = this.ctx;
     if (session.acpSessionId === acpSessionId && !this.pendingAcpIdentityMetadata) return;
     session.acpSessionId = acpSessionId;
@@ -1143,6 +1190,20 @@ export class AcpQueryRunner {
       return;
     }
     db.updateSession(session.id, { acpSessionId });
+  }
+
+  private clearAcpSessionState(): void {
+    const { session, db } = this.ctx;
+    session.acpSessionId = undefined;
+    session.metadata = {
+      ...session.metadata,
+      acpInstructionsSent: undefined,
+      acpContextUsageEstimate: undefined,
+    };
+    db.updateSession(session.id, {
+      acpSessionId: undefined,
+      metadata: session.metadata,
+    });
   }
 
   private persistAcpInstructionsSent(): void {
@@ -1266,6 +1327,8 @@ export class AcpQueryRunner {
       resolveAbort = resolve;
     });
     const onAbort = () => resolveAbort(abortResult);
+    let messageDelivered = false;
+    let pendingNext: Promise<IteratorResult<SDKMessage>> | null = null;
 
     try {
       if (signal.aborted) {
@@ -1275,23 +1338,89 @@ export class AcpQueryRunner {
       signal.addEventListener('abort', onAbort, { once: true });
 
       while (!signal.aborted) {
-        const result = await Promise.race([iterator.next(), abortPromise]);
+        pendingNext = iterator.next();
+        const result = await Promise.race([pendingNext, abortPromise]);
 
-        if ('aborted' in result || signal.aborted) {
+        if ('aborted' in result) {
           break;
         }
+
+        pendingNext = null;
 
         if (result.done) {
           break;
         }
 
+        messageDelivered = true;
         yield result.value;
       }
     } finally {
       signal.removeEventListener('abort', onAbort);
-      try {
-        await iterator.return?.();
-      } catch {}
+      pendingNext?.catch(() => {});
+      if (signal.aborted && messageDelivered) {
+        const drainDeadline = { expired: true } as const;
+        let clearDrainTimer: (() => void) | undefined;
+        const drainTimeout = new Promise<typeof drainDeadline>((resolve) => {
+          const timer = setTimeout(() => resolve(drainDeadline), POST_ABORT_DRAIN_TIMEOUT_MS);
+          timer.unref?.();
+          clearDrainTimer = () => {
+            clearTimeout(timer);
+            resolve(drainDeadline);
+          };
+        });
+        if (pendingNext) {
+          const inFlight = pendingNext;
+          inFlight.catch(() => {});
+          let result: IteratorResult<SDKMessage> | typeof drainDeadline;
+          try {
+            result = await Promise.race([inFlight, drainTimeout]);
+          } catch {
+            result = drainDeadline;
+          }
+          if (
+            !('expired' in result) &&
+            !result.done &&
+            isAcpPostAbortRelevantMessage(result.value)
+          ) {
+            yield result.value;
+          }
+          pendingNext = null;
+        }
+        for (const msg of queryObj.flushPendingMessages()) {
+          yield msg;
+        }
+        let drained = 0;
+        while (drained < MAX_POST_ABORT_DRAIN_MESSAGES) {
+          const next = iterator.next();
+          next.catch(() => {});
+          let result: IteratorResult<SDKMessage> | typeof drainDeadline;
+          try {
+            result = await Promise.race([next, drainTimeout]);
+          } catch {
+            break;
+          }
+          if ('expired' in result) break;
+          if (result.done) break;
+          drained++;
+          if (isAcpPostAbortRelevantMessage(result.value)) {
+            yield result.value;
+          }
+        }
+        clearDrainTimer?.();
+      }
+      if (signal.aborted) {
+        try {
+          const settled = new Promise<void>((resolve) => {
+            const timer = setTimeout(resolve, POST_ABORT_DRAIN_TIMEOUT_MS);
+            timer.unref?.();
+          });
+          await Promise.race([Promise.resolve(iterator.return?.()), settled]);
+        } catch {}
+      } else {
+        try {
+          await iterator.return?.();
+        } catch {}
+      }
     }
   }
 

--- a/packages/daemon/src/lib/agent/query-lifecycle-manager.ts
+++ b/packages/daemon/src/lib/agent/query-lifecycle-manager.ts
@@ -81,10 +81,14 @@ export class QueryLifecycleManager {
       session.acpSessionId = undefined;
       updates.acpSessionId = undefined;
     }
-    if (session.metadata?.acpInstructionsSent) {
+    if (
+      session.metadata?.acpInstructionsSent ||
+      session.metadata?.acpContextUsageEstimate !== undefined
+    ) {
       session.metadata = {
         ...session.metadata,
         acpInstructionsSent: undefined,
+        acpContextUsageEstimate: undefined,
       };
       updates.metadata = session.metadata;
     }
@@ -186,10 +190,14 @@ export class QueryLifecycleManager {
     const processExitedPromise = this.ctx.processExitedPromise;
     const trackedProcessSnapshot = this.ctx.snapshotTrackedAgentProcesses();
     const noPidProcessSnapshot = this.ctx.snapshotNoPidTrackedProcesses?.() ?? [];
+    const queryAbortController = this.ctx.queryAbortController;
+    const queryPromise = this.ctx.queryPromise;
+    const queryObject = this.ctx.queryObject;
+    const startupTimeoutTimer = this.ctx.startupTimeoutTimer;
 
     messageQueue.stop();
+    queryAbortController?.abort();
 
-    const queryObject = this.ctx.queryObject;
     if (queryObject && typeof queryObject.interrupt === 'function') {
       if (this.ctx.firstMessageReceived) {
         try {
@@ -198,7 +206,6 @@ export class QueryLifecycleManager {
       }
     }
 
-    const queryPromise = this.ctx.queryPromise;
     if (queryPromise) {
       try {
         const promiseToAwait = catchQueryErrors ? queryPromise.catch(() => {}) : queryPromise;
@@ -216,6 +223,19 @@ export class QueryLifecycleManager {
       noPidProcesses: noPidProcessSnapshot,
     });
 
+    if (this.ctx.queryPromise === queryPromise) {
+      const lateProcesses = this.ctx
+        .snapshotTrackedAgentProcesses()
+        .filter((process) => !trackedProcessSnapshot.some((entry) => entry[1] === process[1]));
+      if (lateProcesses.length > 0) {
+        this.ctx.terminateTrackedAgentProcesses({
+          forceDelayMs: FORCE_PROCESS_KILL_DELAY_MS,
+          processes: lateProcesses,
+          noPidProcesses: [],
+        });
+      }
+    }
+
     if (queryObject && this.ctx.queryObject === queryObject) {
       try {
         queryObject.close();
@@ -231,17 +251,25 @@ export class QueryLifecycleManager {
     }
 
     const staleTimer = this.ctx.startupTimeoutTimer;
-    if (staleTimer) {
+    if (staleTimer && staleTimer === startupTimeoutTimer) {
       clearTimeout(staleTimer);
       this.ctx.startupTimeoutTimer = null;
     }
     const staleAbort = this.ctx.queryAbortController;
-    if (staleAbort) {
-      this.ctx.queryAbortController = null;
+    if (
+      staleAbort &&
+      staleAbort !== queryAbortController &&
+      this.ctx.queryPromise === queryPromise
+    ) {
+      staleAbort.abort();
     }
-
-    this.ctx.queryObject = null;
-    this.ctx.queryPromise = null;
+    if (this.ctx.queryPromise === queryPromise) {
+      this.ctx.queryAbortController = null;
+      this.ctx.queryPromise = null;
+    }
+    if (this.ctx.queryObject === queryObject) {
+      this.ctx.queryObject = null;
+    }
   }
 
   async restart(): Promise<void> {

--- a/packages/daemon/tests/unit/1-core/agent/query-lifecycle-manager.test.ts
+++ b/packages/daemon/tests/unit/1-core/agent/query-lifecycle-manager.test.ts
@@ -168,6 +168,132 @@ describe('QueryLifecycleManager', () => {
       expect(stopSpy).toHaveBeenCalled();
     });
 
+    test('aborts the active query before waiting for it to stop', async () => {
+      const abortController = new AbortController();
+      let observedAbort = false;
+      mockContext.queryAbortController = abortController;
+      mockContext.queryPromise = new Promise((resolve) => {
+        abortController.signal.addEventListener('abort', () => {
+          observedAbort = true;
+          resolve();
+        });
+      });
+      manager = new QueryLifecycleManager(mockContext);
+
+      await manager.stop();
+
+      expect(observedAbort).toBe(true);
+      expect(abortController.signal.aborted).toBe(true);
+    });
+
+    test('aborts only the query controller captured when stop begins', async () => {
+      const entryController = new AbortController();
+      const newerController = new AbortController();
+      mockContext.queryAbortController = entryController;
+      const originalStop = messageQueue.stop.bind(messageQueue);
+      const stopSpy = spyOn(messageQueue, 'stop');
+      stopSpy.mockImplementation(() => {
+        mockContext.queryAbortController = newerController;
+        mockContext.queryPromise = Promise.resolve();
+        originalStop();
+      });
+      manager = new QueryLifecycleManager(mockContext);
+
+      await manager.stop();
+
+      expect(entryController.signal.aborted).toBe(true);
+      expect(newerController.signal.aborted).toBe(false);
+    });
+
+    test('preserves replacement query references installed during stop', async () => {
+      const entryController = new AbortController();
+      const newerController = new AbortController();
+      const newerQueryObject = { interrupt: mock(async () => {}) };
+      const newerPromise = Promise.resolve();
+      mockContext.queryAbortController = entryController;
+      mockContext.queryPromise = new Promise(() => {});
+      const originalStop = messageQueue.stop.bind(messageQueue);
+      spyOn(messageQueue, 'stop').mockImplementation(() => {
+        mockContext.queryAbortController = newerController;
+        mockContext.queryObject = newerQueryObject as never;
+        mockContext.queryPromise = newerPromise;
+        originalStop();
+      });
+      manager = new QueryLifecycleManager(mockContext);
+
+      await manager.stop({ timeoutMs: 50 });
+
+      expect(newerController.signal.aborted).toBe(false);
+      expect(mockContext.queryAbortController).toBe(newerController);
+      expect(mockContext.queryObject).toBe(newerQueryObject);
+      expect(mockContext.queryPromise).toBe(newerPromise);
+    });
+
+    test('preserves a replacement startup timer installed during stop', async () => {
+      const entryTimer = setTimeout(() => {}, 10_000);
+      const newerTimer = setTimeout(() => {}, 10_000);
+      mockContext.startupTimeoutTimer = entryTimer;
+      const originalStop = messageQueue.stop.bind(messageQueue);
+      spyOn(messageQueue, 'stop').mockImplementation(() => {
+        mockContext.startupTimeoutTimer = newerTimer;
+        mockContext.queryPromise = Promise.resolve();
+        originalStop();
+      });
+      manager = new QueryLifecycleManager(mockContext);
+
+      await manager.stop();
+
+      expect(mockContext.startupTimeoutTimer).toBe(newerTimer);
+      clearTimeout(newerTimer);
+    });
+
+    test('terminates agent processes discovered during the stop window', async () => {
+      const lateProcess = { pid: 4242, kill: mock(() => {}) } as never;
+      let call = 0;
+      snapshotTrackedAgentProcessesSpy.mockImplementation(() => {
+        call++;
+        return call === 1 ? [] : ([[4242, lateProcess]] as never);
+      });
+
+      manager = new QueryLifecycleManager(mockContext);
+      await manager.stop();
+
+      expect(terminateTrackedAgentProcessesSpy).toHaveBeenCalledTimes(2);
+      expect(terminateTrackedAgentProcessesSpy.mock.calls[1][0]).toEqual({
+        forceDelayMs: expect.any(Number),
+        processes: [[4242, lateProcess]],
+        noPidProcesses: [],
+      });
+    });
+
+    test('aborts a controller installed by the stopped query during the stop window', async () => {
+      const lateController = new AbortController();
+      mockContext.queryPromise = new Promise(() => {});
+      manager = new QueryLifecycleManager(mockContext);
+
+      const stopping = manager.stop({ timeoutMs: 50 });
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      mockContext.queryAbortController = lateController;
+      await stopping;
+
+      expect(lateController.signal.aborted).toBe(true);
+      expect(mockContext.queryAbortController).toBeNull();
+    });
+
+    test('does not abort a newer query controller installed during the stop window', async () => {
+      const newerController = new AbortController();
+      mockContext.queryPromise = new Promise(() => {});
+      manager = new QueryLifecycleManager(mockContext);
+
+      const stopping = manager.stop({ timeoutMs: 50 });
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      mockContext.queryAbortController = newerController;
+      mockContext.queryPromise = Promise.resolve();
+      await stopping;
+
+      expect(newerController.signal.aborted).toBe(false);
+    });
+
     test('interrupts query when transport is ready', async () => {
       let interruptCalled = false;
       mockContext.queryObject = {
@@ -595,7 +721,10 @@ describe('QueryLifecycleManager', () => {
     test('clears ACP resume state on reset when no query is running', async () => {
       mockContext.session.config.provider = 'acp';
       mockContext.session.acpSessionId = 'stale-acp-session';
-      mockContext.session.metadata = { acpInstructionsSent: true } as Session['metadata'];
+      mockContext.session.metadata = {
+        acpInstructionsSent: true,
+        acpContextUsageEstimate: 12000,
+      } as Session['metadata'];
       manager = new QueryLifecycleManager(mockContext);
 
       const result = await manager.reset();
@@ -603,11 +732,15 @@ describe('QueryLifecycleManager', () => {
       expect(result.success).toBe(true);
       expect(mockContext.session.acpSessionId).toBeUndefined();
       expect(mockContext.session.metadata.acpInstructionsSent).toBeUndefined();
+      expect(mockContext.session.metadata.acpContextUsageEstimate).toBeUndefined();
       expect(updateSessionSpy).toHaveBeenCalledWith(
         'test-session',
         expect.objectContaining({
           acpSessionId: undefined,
-          metadata: expect.objectContaining({ acpInstructionsSent: undefined }),
+          metadata: expect.objectContaining({
+            acpInstructionsSent: undefined,
+            acpContextUsageEstimate: undefined,
+          }),
         })
       );
     });
@@ -619,7 +752,10 @@ describe('QueryLifecycleManager', () => {
       mockContext.queryPromise = Promise.resolve();
       mockContext.session.config.provider = 'acp';
       mockContext.session.acpSessionId = 'stale-acp-session';
-      mockContext.session.metadata = { acpInstructionsSent: true } as Session['metadata'];
+      mockContext.session.metadata = {
+        acpInstructionsSent: true,
+        acpContextUsageEstimate: 12000,
+      } as Session['metadata'];
       manager = new QueryLifecycleManager(mockContext);
 
       const result = await manager.reset({ restartAfter: true });
@@ -627,11 +763,15 @@ describe('QueryLifecycleManager', () => {
       expect(result.success).toBe(true);
       expect(mockContext.session.acpSessionId).toBeUndefined();
       expect(mockContext.session.metadata.acpInstructionsSent).toBeUndefined();
+      expect(mockContext.session.metadata.acpContextUsageEstimate).toBeUndefined();
       expect(updateSessionSpy).toHaveBeenCalledWith(
         'test-session',
         expect.objectContaining({
           acpSessionId: undefined,
-          metadata: expect.objectContaining({ acpInstructionsSent: undefined }),
+          metadata: expect.objectContaining({
+            acpInstructionsSent: undefined,
+            acpContextUsageEstimate: undefined,
+          }),
         })
       );
       expect(startStreamingCalled).toBe(true);

--- a/packages/daemon/tests/unit/lib/acp/acp-query-runner.test.ts
+++ b/packages/daemon/tests/unit/lib/acp/acp-query-runner.test.ts
@@ -1748,4 +1748,343 @@ describe('AcpQueryRunner', () => {
     expect(client.sendPrompt).toHaveBeenCalled();
     expect(ctx.errorManager.handleError).not.toHaveBeenCalled();
   }, 1000);
+
+  test('closes the ACP client when the query becomes stale during startup', async () => {
+    const client = createMockClient();
+    let releaseInitialize: (() => void) | undefined;
+    let markInitializeStarted: (() => void) | undefined;
+    const initializeStarted = new Promise<void>((resolve) => {
+      markInitializeStarted = resolve;
+    });
+    const initializeGate = new Promise<void>((resolve) => {
+      releaseInitialize = resolve;
+    });
+    client.initialize.mockImplementation(async () => {
+      markInitializeStarted?.();
+      await initializeGate;
+      return { protocolVersion: 1, agentCapabilities: {}, agentInfo: {} };
+    });
+    const { runner, ctx } = createRunnerFixture({ client });
+
+    await runner.start();
+    await initializeStarted;
+    ctx.incrementQueryGeneration();
+    releaseInitialize?.();
+    await ctx.queryPromise;
+
+    expect(client.sendPrompt).not.toHaveBeenCalled();
+    expect(client.close).toHaveBeenCalled();
+    expect(ctx.errorManager.handleError).not.toHaveBeenCalled();
+  });
+
+  test('delivers an interrupted tool call with its synthesized result', async () => {
+    const client = createMockClient();
+    let releasePrompt: (() => void) | undefined;
+    let promptBlockedResolve: (() => void) | undefined;
+    const promptBlocked = new Promise<void>((resolve) => {
+      promptBlockedResolve = resolve;
+    });
+    client.sendPrompt.mockImplementation(async function* () {
+      yield {
+        sessionId: 'acp-session-1',
+        update: { sessionUpdate: 'plan', entries: [] },
+      };
+      await new Promise<void>((resolve) => {
+        releasePrompt = resolve;
+        promptBlockedResolve?.();
+      });
+      yield {
+        sessionId: 'acp-session-1',
+        update: {
+          sessionUpdate: 'tool_call',
+          toolCallId: 'tc-late',
+          title: 'Late tool',
+          rawInput: {},
+        },
+      };
+    });
+    const { runner, ctx, onSDKMessage } = createRunnerFixture({ client });
+
+    await runner.start();
+    await promptBlocked;
+    ctx.queryAbortController?.abort();
+    releasePrompt?.();
+    await ctx.queryPromise;
+
+    const hasToolUse = onSDKMessage.mock.calls.some(
+      ([message]) =>
+        message.type === 'assistant' &&
+        (
+          (message as { message?: { content?: Array<{ type?: string }> } }).message?.content ?? []
+        ).some((block) => block?.type === 'tool_use')
+    );
+    const hasToolResult = onSDKMessage.mock.calls.some(
+      ([message]) =>
+        message.type === 'user' && (message as SDKUserMessage).parent_tool_use_id === 'tc-late'
+    );
+    expect(hasToolUse).toBe(true);
+    expect(hasToolResult).toBe(true);
+    expect(ctx.errorManager.handleError).not.toHaveBeenCalled();
+  }, 1000);
+
+  test('aborts stale ACP startup after cleanup begins', async () => {
+    let markBuildStarted: () => void;
+    const buildStarted = new Promise<void>((resolve) => {
+      markBuildStarted = resolve;
+    });
+    let releaseBuild: () => void;
+    const buildGate = new Promise<void>((resolve) => {
+      releaseBuild = resolve;
+    });
+    const { runner, ctx, constructorOptions } = createRunnerFixture({
+      queryOptions: { cwd: '/tmp/acp-session', mcpServers: {} },
+    });
+    ctx.optionsBuilder.build = mock(async () => {
+      markBuildStarted();
+      await buildGate;
+      return { cwd: '/tmp/acp-session', mcpServers: {} };
+    });
+
+    await runner.start();
+    await buildStarted;
+    ctx.isCleaningUp = () => true;
+    releaseBuild!();
+    await ctx.queryPromise;
+
+    expect(constructorOptions).toHaveLength(0);
+    expect(ctx.queryAbortController).toBeNull();
+  });
+
+  test('aborts stale ACP startup after cleanup begins', async () => {
+    let markBuildStarted: () => void;
+    const buildStarted = new Promise<void>((resolve) => {
+      markBuildStarted = resolve;
+    });
+    let releaseBuild: () => void;
+    const buildGate = new Promise<void>((resolve) => {
+      releaseBuild = resolve;
+    });
+    const { runner, ctx, constructorOptions } = createRunnerFixture({
+      queryOptions: { cwd: '/tmp/acp-session', mcpServers: {} },
+    });
+    ctx.optionsBuilder.build = mock(async () => {
+      markBuildStarted();
+      await buildGate;
+      return { cwd: '/tmp/acp-session', mcpServers: {} };
+    });
+
+    await runner.start();
+    await buildStarted;
+    ctx.isCleaningUp = () => true;
+    releaseBuild!();
+    await ctx.queryPromise;
+
+    expect(constructorOptions).toHaveLength(0);
+    expect(ctx.queryAbortController).toBeNull();
+  });
+
+  test('stops iteration without error when abort signal fires', async () => {
+    const client = createMockClient();
+    let releasePrompt: (() => void) | undefined;
+    let promptBlockedResolve: (() => void) | undefined;
+    const promptBlocked = new Promise<void>((resolve) => {
+      promptBlockedResolve = resolve;
+    });
+    client.sendPrompt.mockImplementation(async function* () {
+      yield {
+        sessionId: 'acp-session-1',
+        update: {
+          sessionUpdate: 'agent_message_chunk',
+          content: { type: 'text', text: 'before abort' },
+        },
+      };
+      await new Promise<void>((resolve) => {
+        releasePrompt = resolve;
+        promptBlockedResolve?.();
+      });
+    });
+    const { runner, ctx } = createRunnerFixture({ client });
+
+    await runner.start();
+    await promptBlocked;
+    ctx.queryAbortController?.abort();
+    releasePrompt?.();
+    await ctx.queryPromise;
+
+    expect(client.sendPrompt).toHaveBeenCalled();
+    expect(ctx.errorManager.handleError).not.toHaveBeenCalled();
+  }, 1000);
+
+  test('delivers pending ACP tool results when abort drops the iterator output', async () => {
+    const client = createMockClient();
+    let releasePrompt: (() => void) | undefined;
+    let promptBlockedResolve: (() => void) | undefined;
+    const promptBlocked = new Promise<void>((resolve) => {
+      promptBlockedResolve = resolve;
+    });
+    client.sendPrompt.mockImplementation(async function* () {
+      yield {
+        sessionId: 'acp-session-1',
+        update: {
+          sessionUpdate: 'tool_call',
+          toolCallId: 'tc-interrupted',
+          title: 'Long tool',
+          rawInput: {},
+        },
+      };
+      await new Promise<void>((resolve) => {
+        releasePrompt = resolve;
+        promptBlockedResolve?.();
+      });
+    });
+    const { runner, ctx, onSDKMessage } = createRunnerFixture({ client });
+
+    await runner.start();
+    await promptBlocked;
+    ctx.queryAbortController?.abort();
+    releasePrompt?.();
+    await ctx.queryPromise;
+
+    expect(
+      onSDKMessage.mock.calls.some(
+        ([message]) =>
+          message.type === 'user' &&
+          (message as SDKUserMessage).parent_tool_use_id === 'tc-interrupted'
+      )
+    ).toBe(true);
+    expect(ctx.errorManager.handleError).not.toHaveBeenCalled();
+  }, 1000);
+
+  test('does not duplicate tool results completed during abort', async () => {
+    const client = createMockClient();
+    let releasePrompt: (() => void) | undefined;
+    let promptBlockedResolve: (() => void) | undefined;
+    const promptBlocked = new Promise<void>((resolve) => {
+      promptBlockedResolve = resolve;
+    });
+    client.sendPrompt.mockImplementation(async function* () {
+      yield {
+        sessionId: 'acp-session-1',
+        update: {
+          sessionUpdate: 'tool_call',
+          toolCallId: 'tc-interrupted',
+          title: 'Long tool',
+          rawInput: {},
+        },
+      };
+      await new Promise<void>((resolve) => {
+        releasePrompt = resolve;
+        promptBlockedResolve?.();
+      });
+      yield {
+        sessionId: 'acp-session-1',
+        update: {
+          sessionUpdate: 'tool_call_update',
+          toolCallId: 'tc-interrupted',
+          status: 'completed',
+        },
+      };
+    });
+    const { runner, ctx, onSDKMessage } = createRunnerFixture({ client });
+
+    await runner.start();
+    await promptBlocked;
+    ctx.queryAbortController?.abort();
+    releasePrompt?.();
+    await ctx.queryPromise;
+
+    const toolResults = onSDKMessage.mock.calls.filter(
+      ([message]) =>
+        message.type === 'user' &&
+        (message as SDKUserMessage).parent_tool_use_id === 'tc-interrupted'
+    );
+    expect(toolResults.length).toBe(1);
+    expect(ctx.errorManager.handleError).not.toHaveBeenCalled();
+  }, 1000);
+
+  test('settles the query when the agent stops responding after abort', async () => {
+    const client = createMockClient();
+    let promptBlockedResolve: (() => void) | undefined;
+    const promptBlocked = new Promise<void>((resolve) => {
+      promptBlockedResolve = resolve;
+    });
+    client.sendPrompt.mockImplementation(async function* () {
+      yield {
+        sessionId: 'acp-session-1',
+        update: {
+          sessionUpdate: 'tool_call',
+          toolCallId: 'tc-interrupted',
+          title: 'Long tool',
+          rawInput: {},
+        },
+      };
+      promptBlockedResolve?.();
+      await new Promise<void>(() => {});
+    });
+    const { runner, ctx, onSDKMessage } = createRunnerFixture({ client });
+
+    await runner.start();
+    await promptBlocked;
+    ctx.queryAbortController?.abort();
+    await ctx.queryPromise;
+
+    expect(
+      onSDKMessage.mock.calls.some(
+        ([message]) =>
+          message.type === 'user' &&
+          (message as SDKUserMessage).parent_tool_use_id === 'tc-interrupted'
+      )
+    ).toBe(true);
+    expect(ctx.errorManager.handleError).not.toHaveBeenCalled();
+  }, 5000);
+
+  test('stops draining a continuing producer after abort', async () => {
+    const client = createMockClient();
+    let releasePrompt: (() => void) | undefined;
+    let promptBlockedResolve: (() => void) | undefined;
+    const promptBlocked = new Promise<void>((resolve) => {
+      promptBlockedResolve = resolve;
+    });
+    client.sendPrompt.mockImplementation(async function* () {
+      yield {
+        sessionId: 'acp-session-1',
+        update: {
+          sessionUpdate: 'tool_call',
+          toolCallId: 'tc-interrupted',
+          title: 'Long tool',
+          rawInput: {},
+        },
+      };
+      await new Promise<void>((resolve) => {
+        releasePrompt = resolve;
+        promptBlockedResolve?.();
+      });
+      while (true) {
+        yield {
+          sessionId: 'acp-session-1',
+          update: { sessionUpdate: 'plan', entries: [] },
+        };
+      }
+    });
+    const { runner, ctx, onSDKMessage } = createRunnerFixture({ client });
+
+    await runner.start();
+    await promptBlocked;
+    ctx.queryAbortController?.abort();
+    releasePrompt?.();
+    await ctx.queryPromise;
+
+    expect(
+      onSDKMessage.mock.calls.some(
+        ([message]) =>
+          message.type === 'user' &&
+          (message as SDKUserMessage).parent_tool_use_id === 'tc-interrupted'
+      )
+    ).toBe(true);
+    expect(
+      onSDKMessage.mock.calls.filter(([message]) => message.type === 'assistant').length
+    ).toBeLessThanOrEqual(2);
+    expect(onSDKMessage.mock.calls.length).toBeLessThanOrEqual(10);
+    expect(ctx.errorManager.handleError).not.toHaveBeenCalled();
+  }, 1000);
 });

--- a/packages/daemon/tests/unit/lib/acp/acp-query-runner.test.ts
+++ b/packages/daemon/tests/unit/lib/acp/acp-query-runner.test.ts
@@ -1855,66 +1855,6 @@ describe('AcpQueryRunner', () => {
     expect(ctx.queryAbortController).toBeNull();
   });
 
-  test('aborts stale ACP startup after cleanup begins', async () => {
-    let markBuildStarted: () => void;
-    const buildStarted = new Promise<void>((resolve) => {
-      markBuildStarted = resolve;
-    });
-    let releaseBuild: () => void;
-    const buildGate = new Promise<void>((resolve) => {
-      releaseBuild = resolve;
-    });
-    const { runner, ctx, constructorOptions } = createRunnerFixture({
-      queryOptions: { cwd: '/tmp/acp-session', mcpServers: {} },
-    });
-    ctx.optionsBuilder.build = mock(async () => {
-      markBuildStarted();
-      await buildGate;
-      return { cwd: '/tmp/acp-session', mcpServers: {} };
-    });
-
-    await runner.start();
-    await buildStarted;
-    ctx.isCleaningUp = () => true;
-    releaseBuild!();
-    await ctx.queryPromise;
-
-    expect(constructorOptions).toHaveLength(0);
-    expect(ctx.queryAbortController).toBeNull();
-  });
-
-  test('stops iteration without error when abort signal fires', async () => {
-    const client = createMockClient();
-    let releasePrompt: (() => void) | undefined;
-    let promptBlockedResolve: (() => void) | undefined;
-    const promptBlocked = new Promise<void>((resolve) => {
-      promptBlockedResolve = resolve;
-    });
-    client.sendPrompt.mockImplementation(async function* () {
-      yield {
-        sessionId: 'acp-session-1',
-        update: {
-          sessionUpdate: 'agent_message_chunk',
-          content: { type: 'text', text: 'before abort' },
-        },
-      };
-      await new Promise<void>((resolve) => {
-        releasePrompt = resolve;
-        promptBlockedResolve?.();
-      });
-    });
-    const { runner, ctx } = createRunnerFixture({ client });
-
-    await runner.start();
-    await promptBlocked;
-    ctx.queryAbortController?.abort();
-    releasePrompt?.();
-    await ctx.queryPromise;
-
-    expect(client.sendPrompt).toHaveBeenCalled();
-    expect(ctx.errorManager.handleError).not.toHaveBeenCalled();
-  }, 1000);
-
   test('delivers pending ACP tool results when abort drops the iterator output', async () => {
     const client = createMockClient();
     let releasePrompt: (() => void) | undefined;


### PR DESCRIPTION
Extracted from #2711 (ACP split 8/10) — final slice of the stack.

## What this adds

**Query runner:**
- `createAbortableQuery` keeps the in-flight `iterator.next()` promise; on abort it no longer drops that message. Post-abort, tool-result/tool-use messages in flight or still queued are drained (bounded: ≤256 messages, 1 s deadline) and yielded, and pending adapter messages flush — interrupted tool calls end with synthesized results instead of hanging the next turn. A late producer that never yields stops after the deadline.
- Startup aborts as soon as cleanup begins (5 `assertActiveAcpStartup` checkpoints: pre-controller, post-callbacks, post-client, post-authenticate, post-models-fetch) instead of running the whole handshake against a dead query.
- Startup-timeout path cancels and closes the session before closing the client (retry starts clean); stale queries close a leftover client in `finally`; `_lastConsumedUserMessage` clears when the query settles.
- `clearAcpSessionState()` replaces the `persistAcpSessionId(undefined)` retry hack and also clears instructions/context estimate.

**QueryLifecycleManager:**
- Aborts the active query controller *before* waiting on stop; terminates agent processes discovered during the stop window; only clears `queryAbortController`/`queryPromise`/`queryObject`/startup timer when a replacement query has not already installed new references; reset also clears `acpContextUsageEstimate`.

Tests: +9 runner tests (abort drain, dedupe of results completed during abort, stale-startup aborts, stale client close, interrupted tool call delivery, bounded drain of continuing producers) and +7 lifecycle stop-window tests. 321 passed / 21 skipped across the touched suites.

Extracted from #2711.

## Verification

- `vitest run tests/unit/lib/acp/ tests/unit/1-core/agent/query-lifecycle-manager.test.ts tests/unit/1-core/acp-transport.test.ts` — 321 passed / 21 skipped
- oxlint, `tsc --build --noEmit`, knip, pinned-biome — clean
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/lsm/hyperneo/pull/2792" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->