### PR TITLE
refactor(daemon): extract text/content projections + renderable-text predicate (chain A PR 3/5)

### DIFF
--- a/packages/daemon/src/storage/repositories/sdk-message-projections.ts
+++ b/packages/daemon/src/storage/repositories/sdk-message-projections.ts
@@ -95,3 +95,87 @@ export function inflatePersistedMessage(row: {
     timestamp: new Date(row.timestamp).getTime(),
   } as SDKMessage & { dbId: string; timestamp: number };
 }
+
+export function extractVisibleText(msg: Record<string, unknown>): string {
+  const parts: string[] = [];
+  const message = msg.message as Record<string, unknown> | undefined;
+  const content = message?.content;
+  if (Array.isArray(content)) {
+    for (const block of content as Array<Record<string, unknown>>) {
+      if (block.type === 'text' && typeof block.text === 'string') {
+        parts.push(block.text);
+      }
+    }
+  } else if (typeof content === 'string') {
+    parts.push(content);
+  }
+  if (msg.type === 'result' && typeof msg.result === 'string') {
+    parts.push(msg.result);
+  }
+  return parts.join('\n\n').trim();
+}
+
+export function extractToolCallNames(msg: Record<string, unknown>): string[] {
+  const names: string[] = [];
+  const message = msg.message as Record<string, unknown> | undefined;
+  const content = message?.content;
+  if (Array.isArray(content)) {
+    for (const block of content as Array<Record<string, unknown>>) {
+      if (block.type === 'tool_use' && typeof block.name === 'string') {
+        names.push(block.name);
+      }
+    }
+  }
+  return names;
+}
+
+export function extractFirstTextBlockContent(message: SDKMessage): string {
+  const content = (
+    message as { message?: { content?: string | Array<{ type: string; text?: string }> } }
+  ).message?.content;
+  if (typeof content === 'string') return content;
+  if (Array.isArray(content)) {
+    const textBlock = content.find(
+      (block): block is { type: 'text'; text: string } => block.type === 'text'
+    );
+    return textBlock?.text || '';
+  }
+  return '';
+}
+
+export interface RenderableTextMessageRow {
+  id: string;
+  message_type: string;
+  sdk_message: string;
+  timestamp: string;
+}
+
+export interface RenderableTextMessage {
+  id: string;
+  type: string;
+  text: string;
+  timestamp: number;
+}
+
+export function projectRenderableTextRow(
+  row: RenderableTextMessageRow
+): RenderableTextMessage | null {
+  const message = parseSdkMessageRow(row.sdk_message, 'skip');
+  if (!message) return null;
+  const text = extractVisibleText(message as unknown as Record<string, unknown>);
+  if (text.length === 0) return null;
+  return {
+    id: row.id,
+    type: row.message_type,
+    text,
+    timestamp: new Date(row.timestamp).getTime(),
+  };
+}
+
+export const RENDERABLE_TEXT_MESSAGE_BATCH_SIZE = 50;
+
+const RENDERABLE_TEXT_MESSAGE_MAX_SCAN = 250;
+
+export function resolveRenderableTextScanBudget(limit: number): number {
+  return Math.max(limit, RENDERABLE_TEXT_MESSAGE_MAX_SCAN);
+}

--- a/packages/daemon/src/storage/repositories/sdk-message-repository.ts
+++ b/packages/daemon/src/storage/repositories/sdk-message-repository.ts
@@ -12,12 +12,20 @@ import { HIDDEN_SYSTEM_SUBTYPES } from '@hyperneo/shared/sdk/type-guards';
 import type { ReactiveDatabase } from '../reactive-database';
 import { Logger } from '../../lib/logger';
 import {
+  RENDERABLE_TEXT_MESSAGE_BATCH_SIZE,
+  extractFirstTextBlockContent,
+  extractToolCallNames,
+  extractVisibleText,
   inflatePersistedMessage,
   projectBackgroundTaskMessageRow,
+  projectRenderableTextRow,
   projectSubagentMessageRow,
   projectTopLevelMessageRow,
+  resolveRenderableTextScanBudget,
   type BackgroundTaskMessageRow,
   type PaginationMessageRow,
+  type RenderableTextMessage,
+  type RenderableTextMessageRow,
   type SubagentMessageRow,
 } from './sdk-message-projections';
 import {
@@ -47,8 +55,6 @@ export {
 } from './sdk-message-admission';
 export type { SDKMessageReplacementEdge, SendStatus } from './sdk-message-admission';
 
-const RENDERABLE_TEXT_MESSAGE_BATCH_SIZE = 50;
-const RENDERABLE_TEXT_MESSAGE_MAX_SCAN = 250;
 const STATUS_MESSAGE_HYDRATION_BATCH_SIZE = 900;
 const USER_STATUS_MESSAGE_SQL = `message_type = 'user'
   AND json_valid(sdk_message)
@@ -490,11 +496,8 @@ export class SDKMessageRepository {
     );
   }
 
-  getRenderableTextMessages(
-    sessionId: string,
-    limit = 20
-  ): Array<{ id: string; type: string; text: string; timestamp: number }> {
-    const messages: Array<{ id: string; type: string; text: string; timestamp: number }> = [];
+  getRenderableTextMessages(sessionId: string, limit = 20): Array<RenderableTextMessage> {
+    const messages: Array<RenderableTextMessage> = [];
     const stmt = this.db.prepare(
       `SELECT id, message_type, sdk_message, timestamp FROM sdk_messages
 			 WHERE session_id = ?
@@ -511,34 +514,17 @@ export class SDKMessageRepository {
 			 ORDER BY timestamp DESC, rowid DESC
 			 LIMIT ? OFFSET ?`
     );
-    const maxScan = Math.max(limit, RENDERABLE_TEXT_MESSAGE_MAX_SCAN);
+    const maxScan = resolveRenderableTextScanBudget(limit);
     let scanned = 0;
 
     while (messages.length < limit && scanned < maxScan) {
       const batchSize = Math.min(RENDERABLE_TEXT_MESSAGE_BATCH_SIZE, maxScan - scanned);
-      const rows = stmt.all(sessionId, batchSize, scanned) as Array<{
-        id: string;
-        message_type: string;
-        sdk_message: string;
-        timestamp: string;
-      }>;
+      const rows = stmt.all(sessionId, batchSize, scanned) as Array<RenderableTextMessageRow>;
       if (rows.length === 0) break;
 
       for (const row of rows) {
-        let message: SDKMessage;
-        try {
-          message = JSON.parse(row.sdk_message) as SDKMessage;
-        } catch {
-          continue;
-        }
-        const text = this.extractVisibleText(message as unknown as Record<string, unknown>);
-        if (text.length === 0) continue;
-        messages.push({
-          id: row.id,
-          type: row.message_type,
-          text,
-          timestamp: new Date(row.timestamp).getTime(),
-        });
+        const projected = projectRenderableTextRow(row);
+        if (projected) messages.push(projected);
         if (messages.length >= limit) break;
       }
       scanned += rows.length;
@@ -1300,26 +1286,10 @@ export class SDKMessageRepository {
       const message = JSON.parse(row.sdk_message) as SDKMessage;
       const timestamp = new Date(row.timestamp).getTime();
 
-      let content = '';
-      const userMessage = message as {
-        message?: { content?: string | Array<{ type: string; text?: string }> };
-        uuid?: string;
-      };
-      if (userMessage.message?.content) {
-        if (typeof userMessage.message.content === 'string') {
-          content = userMessage.message.content;
-        } else if (Array.isArray(userMessage.message.content)) {
-          const textBlock = userMessage.message.content.find(
-            (block): block is { type: 'text'; text: string } => block.type === 'text'
-          );
-          content = textBlock?.text || '';
-        }
-      }
-
       return {
-        uuid: userMessage.uuid || '',
+        uuid: (message as { uuid?: string }).uuid || '',
         timestamp,
-        content,
+        content: extractFirstTextBlockContent(message),
       };
     });
   }
@@ -1690,23 +1660,7 @@ export class SDKMessageRepository {
     const message = JSON.parse(row.sdk_message) as SDKMessage;
     const timestamp = new Date(row.timestamp).getTime();
 
-    let content = '';
-    const userMessage = message as {
-      message?: { content?: string | Array<{ type: string; text?: string }> };
-      uuid?: string;
-    };
-    if (userMessage.message?.content) {
-      if (typeof userMessage.message.content === 'string') {
-        content = userMessage.message.content;
-      } else if (Array.isArray(userMessage.message.content)) {
-        const textBlock = userMessage.message.content.find(
-          (block): block is { type: 'text'; text: string } => block.type === 'text'
-        );
-        content = textBlock?.text || '';
-      }
-    }
-
-    return { uuid, timestamp, content };
+    return { uuid, timestamp, content: extractFirstTextBlockContent(message) };
   }
 
   getAssistantMessagesSince(
@@ -1742,46 +1696,13 @@ export class SDKMessageRepository {
     return rows.map((row) => {
       const msg = JSON.parse(row.sdk_message) as Record<string, unknown>;
       const text = this.extractAssistantText(msg);
-      const toolCallNames = this.extractToolCallNames(msg);
+      const toolCallNames = extractToolCallNames(msg);
       return { id: row.id, text, toolCallNames };
     });
   }
 
   private extractAssistantText(msg: Record<string, unknown>): string {
-    return this.extractVisibleText(msg);
-  }
-
-  private extractVisibleText(msg: Record<string, unknown>): string {
-    const parts: string[] = [];
-    const message = msg.message as Record<string, unknown> | undefined;
-    const content = message?.content;
-    if (Array.isArray(content)) {
-      for (const block of content as Array<Record<string, unknown>>) {
-        if (block.type === 'text' && typeof block.text === 'string') {
-          parts.push(block.text);
-        }
-      }
-    } else if (typeof content === 'string') {
-      parts.push(content);
-    }
-    if (msg.type === 'result' && typeof msg.result === 'string') {
-      parts.push(msg.result);
-    }
-    return parts.join('\n\n').trim();
-  }
-
-  private extractToolCallNames(msg: Record<string, unknown>): string[] {
-    const names: string[] = [];
-    const message = msg.message as Record<string, unknown> | undefined;
-    const content = message?.content;
-    if (Array.isArray(content)) {
-      for (const block of content as Array<Record<string, unknown>>) {
-        if (block.type === 'tool_use' && typeof block.name === 'string') {
-          names.push(block.name);
-        }
-      }
-    }
-    return names;
+    return extractVisibleText(msg);
   }
 
   countMessagesAfter(sessionId: string, afterTimestamp: number): number {

--- a/packages/daemon/tests/unit/4-space-storage/storage/sdk-message-projections.test.ts
+++ b/packages/daemon/tests/unit/4-space-storage/storage/sdk-message-projections.test.ts
@@ -289,7 +289,7 @@ describe('extractFirstTextBlockContent — first-block-only policy', () => {
 
     expect(extractFirstTextBlockContent(message)).toBe(' Padded first ');
     expect(extractVisibleText(message as unknown as Record<string, unknown>)).toBe(
-      'Padded first\n\nSecond block'
+      'Padded first \n\nSecond block'
     );
   });
 

--- a/packages/daemon/tests/unit/4-space-storage/storage/sdk-message-projections.test.ts
+++ b/packages/daemon/tests/unit/4-space-storage/storage/sdk-message-projections.test.ts
@@ -1,11 +1,16 @@
 import { describe, expect, test } from 'bun:test';
 import type { SDKMessage } from '@hyperneo/shared/sdk';
 import {
+  extractFirstTextBlockContent,
+  extractToolCallNames,
+  extractVisibleText,
   inflatePersistedMessage,
   parseSdkMessageRow,
   projectBackgroundTaskMessageRow,
+  projectRenderableTextRow,
   projectSubagentMessageRow,
   projectTopLevelMessageRow,
+  resolveRenderableTextScanBudget,
 } from '../../../../src/storage/repositories/sdk-message-projections';
 
 const RAW_MALFORMED = '{not-json';
@@ -200,5 +205,163 @@ describe('inflatePersistedMessage', () => {
     expect(inflated.type).toBe('unknown');
     expect((inflated as { rawContent?: string }).rawContent).toBe(RAW_MALFORMED);
     expect(inflated.dbId).toBe('db-bad');
+  });
+});
+
+describe('extractVisibleText — join-all policy', () => {
+  test('joins every text block with blank lines and trims the result', () => {
+    const msg = {
+      type: 'assistant',
+      message: {
+        role: 'assistant',
+        content: [
+          { type: 'text', text: ' Alpha' },
+          { type: 'tool_use', id: 'tu-1', name: 'Read' },
+          { type: 'text', text: 'Beta ' },
+        ],
+      },
+    };
+    expect(extractVisibleText(msg)).toBe('Alpha\n\nBeta');
+  });
+
+  test('returns string content directly', () => {
+    const msg = { type: 'user', message: { role: 'user', content: 'Plain string' } };
+    expect(extractVisibleText(msg)).toBe('Plain string');
+  });
+
+  test('appends the result field for result messages', () => {
+    const msg = { type: 'result', result: 'Final result', message: { content: null } };
+    expect(extractVisibleText(msg)).toBe('Final result');
+  });
+
+  test('returns an empty string when no text content exists', () => {
+    const msg = {
+      type: 'assistant',
+      message: { role: 'assistant', content: [{ type: 'tool_use', id: 'tu-1', name: 'Read' }] },
+    };
+    expect(extractVisibleText(msg)).toBe('');
+    expect(extractVisibleText({ type: 'assistant' })).toBe('');
+  });
+});
+
+describe('extractToolCallNames', () => {
+  test('collects tool_use block names in content order', () => {
+    const msg = {
+      type: 'assistant',
+      message: {
+        role: 'assistant',
+        content: [
+          { type: 'tool_use', id: 'tu-1', name: 'Read' },
+          { type: 'text', text: 'interlude' },
+          { type: 'tool_use', id: 'tu-2', name: 'Edit' },
+        ],
+      },
+    };
+    expect(extractToolCallNames(msg)).toEqual(['Read', 'Edit']);
+  });
+
+  test('returns an empty array for text-only or string content', () => {
+    expect(
+      extractToolCallNames({
+        type: 'assistant',
+        message: { role: 'assistant', content: [{ type: 'text', text: 'hi' }] },
+      })
+    ).toEqual([]);
+    expect(
+      extractToolCallNames({ type: 'user', message: { role: 'user', content: 'hi' } })
+    ).toEqual([]);
+  });
+});
+
+describe('extractFirstTextBlockContent — first-block-only policy', () => {
+  test('returns only the first text block with whitespace preserved, unlike the join-all policy', () => {
+    const message = {
+      type: 'user',
+      uuid: 'uuid-blocks',
+      message: {
+        role: 'user',
+        content: [
+          { type: 'text', text: ' Padded first ' },
+          { type: 'text', text: 'Second block' },
+        ],
+      },
+    } as unknown as SDKMessage;
+
+    expect(extractFirstTextBlockContent(message)).toBe(' Padded first ');
+    expect(extractVisibleText(message as unknown as Record<string, unknown>)).toBe(
+      'Padded first\n\nSecond block'
+    );
+  });
+
+  test('returns string content verbatim', () => {
+    const message = {
+      type: 'user',
+      message: { role: 'user', content: 'Simple string content' },
+    } as unknown as SDKMessage;
+    expect(extractFirstTextBlockContent(message)).toBe('Simple string content');
+  });
+
+  test('returns an empty string when no text block or content exists', () => {
+    const toolOnly = {
+      type: 'user',
+      message: { role: 'user', content: [{ type: 'tool_result', id: 'tu-1' }] },
+    } as unknown as SDKMessage;
+    expect(extractFirstTextBlockContent(toolOnly)).toBe('');
+    expect(extractFirstTextBlockContent({ type: 'user', uuid: 'u' } as unknown as SDKMessage)).toBe(
+      ''
+    );
+    expect(
+      extractFirstTextBlockContent({
+        type: 'user',
+        message: { role: 'user', content: '' },
+      } as unknown as SDKMessage)
+    ).toBe('');
+  });
+});
+
+describe('projectRenderableTextRow', () => {
+  function renderableRow(overrides: Partial<Parameters<typeof projectRenderableTextRow>[0]> = {}) {
+    return {
+      id: 'row-1',
+      message_type: 'assistant',
+      sdk_message: JSON.stringify({
+        type: 'assistant',
+        message: { role: 'assistant', content: [{ type: 'text', text: 'Visible' }] },
+      }),
+      timestamp: TIMESTAMP,
+      ...overrides,
+    };
+  }
+
+  test('projects a row with visible text and row metadata', () => {
+    expect(projectRenderableTextRow(renderableRow({ message_type: 'user', id: 'u-1' }))).toEqual({
+      id: 'u-1',
+      type: 'user',
+      text: 'Visible',
+      timestamp: TIMESTAMP_MS,
+    });
+  });
+
+  test('skips rows whose visible text is empty', () => {
+    const row = renderableRow({
+      sdk_message: JSON.stringify({
+        type: 'assistant',
+        message: { role: 'assistant', content: [{ type: 'tool_use', id: 'tu-1', name: 'Read' }] },
+      }),
+    });
+    expect(projectRenderableTextRow(row)).toBeNull();
+  });
+
+  test('skips malformed rows', () => {
+    expect(projectRenderableTextRow(renderableRow({ sdk_message: RAW_MALFORMED }))).toBeNull();
+  });
+});
+
+describe('resolveRenderableTextScanBudget', () => {
+  test('is max(limit, 250): small limits get the 250-row floor, larger limits grow', () => {
+    expect(resolveRenderableTextScanBudget(1)).toBe(250);
+    expect(resolveRenderableTextScanBudget(20)).toBe(250);
+    expect(resolveRenderableTextScanBudget(250)).toBe(250);
+    expect(resolveRenderableTextScanBudget(400)).toBe(400);
   });
 });


### PR DESCRIPTION
Moves the remaining read transforms out of `sdk-message-repository.ts` into `sdk-message-projections.ts` as plain pure functions (no pipelines in the row loop, per ADR 0004's hot-path rule): `extractVisibleText` (join-all + trim policy), `extractToolCallNames`, the first-block-only user-content shaper `extractFirstTextBlockContent` now shared by `getUserMessages`/`parseUserMessageRow` (kept distinct from the join-all policy — A5 will parameterize the shared primitive), and `projectRenderableTextRow` + `resolveRenderableTextScanBudget` for the renderable-text reader, whose SQL and loop shell stay in the repository with scan budget max(limit, 250). The dead-alias deletion and primitive-sharing cleanup stay scheduled for A5. New unit tests pin each policy (first-block vs join-all, malformed-row skip, scan-budget floor); the A1 characterization pins cover repository-level parity.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/lsm/hyperneo/pull/2793" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->