### PR TITLE
refactor(daemon): unify badge maintenance as instruction set (chain B PR 3/5)

### DIFF
--- a/packages/daemon/src/storage/repositories/sdk-message-badge.ts
+++ b/packages/daemon/src/storage/repositories/sdk-message-badge.ts
@@ -1,0 +1,16 @@
+import type { MessageAdmissionRecord } from './sdk-message-admission';
+
+export type BadgeUpdateInstruction =
+  | { kind: 'none' }
+  | { kind: 'delta'; delta: number }
+  | { kind: 'recompute' };
+
+export function planAdmissionBadgeUpdate(
+  admission: Pick<MessageAdmissionRecord, 'countsTowardsBadge'>
+): BadgeUpdateInstruction {
+  return admission.countsTowardsBadge ? { kind: 'delta', delta: 1 } : { kind: 'none' };
+}
+
+export function planBadgeRecompute(): BadgeUpdateInstruction {
+  return { kind: 'recompute' };
+}

--- a/packages/daemon/src/storage/repositories/sdk-message-repository.ts
+++ b/packages/daemon/src/storage/repositories/sdk-message-repository.ts
@@ -37,6 +37,11 @@ import {
   type SendStatus,
 } from './sdk-message-admission';
 import { decideMessageSearchAdmission } from './message-search-admission';
+import {
+  planAdmissionBadgeUpdate,
+  planBadgeRecompute,
+  type BadgeUpdateInstruction,
+} from './sdk-message-badge';
 
 export {
   computeIsRenderable,
@@ -403,6 +408,7 @@ export class SDKMessageRepository {
         sendStatus: null,
         origin,
       });
+      const badgeUpdate = planAdmissionBadgeUpdate(admission);
       const messageType = message.type;
       const messageSubtype = 'subtype' in message ? (message.subtype as string) : null;
       const timestamp = new Date().toISOString();
@@ -446,10 +452,10 @@ export class SDKMessageRepository {
         }
         this.saveReplacementEdges(id, sessionId, taskId, admission.replacementEdges);
         this.scheduleMessageSearchIndex(id);
-        if (admission.countsTowardsBadge) this.bumpVisibleMessageCount(sessionId, 1);
+        this.applyBadgeUpdate(sessionId, badgeUpdate);
       })();
       try {
-        if (admission.countsTowardsBadge) this.notifySessionsChanged(sessionId);
+        if (badgeUpdate.kind === 'delta') this.notifySessionsChanged(sessionId);
         this.deleteSupersededMessageSearchRows(sessionId, message);
       } catch (error) {
         this.logger.error('[Database] Post-commit side effects failed for SDK message:', error);
@@ -874,6 +880,15 @@ export class SDKMessageRepository {
     return result.changes > 0;
   }
 
+  private applyBadgeUpdate(sessionId: string, instruction: BadgeUpdateInstruction): boolean {
+    if (instruction.kind === 'delta') {
+      this.bumpVisibleMessageCount(sessionId, instruction.delta);
+      return true;
+    }
+    if (instruction.kind === 'recompute') return this.recomputeVisibleMessageCount(sessionId);
+    return false;
+  }
+
   private notifySessionsChanged(sessionId: string): void {
     this.reactiveDb?.notifyChange('sessions', { sessionId });
   }
@@ -938,7 +953,7 @@ export class SDKMessageRepository {
     stmt.run(...values, conversationTurnIndex, admission.sdkUuid);
     this.saveReplacementEdges(id, sessionId, taskId, admission.replacementEdges);
     this.scheduleMessageSearchIndex(id);
-    if (admission.countsTowardsBadge) this.bumpVisibleMessageCount(sessionId, 1);
+    this.applyBadgeUpdate(sessionId, planAdmissionBadgeUpdate(admission));
     return { id, countsTowardsBadge: admission.countsTowardsBadge };
   }
 
@@ -1105,6 +1120,7 @@ export class SDKMessageRepository {
       `UPDATE sdk_messages SET send_status = ? WHERE id IN (${placeholders})`
     );
     const changedSessions: string[] = [];
+    const badgeUpdate = planBadgeRecompute();
     this.db.transaction(() => {
       stmt.run(newStatus, ...messageIds);
 
@@ -1147,7 +1163,7 @@ export class SDKMessageRepository {
       }
 
       for (const { sid } of affectedSessions) {
-        if (this.recomputeVisibleMessageCount(sid)) changedSessions.push(sid);
+        if (this.applyBadgeUpdate(sid, badgeUpdate)) changedSessions.push(sid);
       }
     })();
     for (const sid of changedSessions) this.notifySessionsChanged(sid);
@@ -1199,7 +1215,7 @@ export class SDKMessageRepository {
       deleted =
         deleteStmt.run(sessionId, messageId, expectedStatus ?? null, expectedStatus ?? null)
           .changes > 0;
-      if (deleted) this.recomputeVisibleMessageCount(sessionId);
+      if (deleted) this.applyBadgeUpdate(sessionId, planBadgeRecompute());
     })();
 
     if (!deleted) {
@@ -1256,7 +1272,7 @@ export class SDKMessageRepository {
     let badgeChanged = false;
     this.db.transaction(() => {
       deleted = stmt.run(sessionId, isoTimestamp).changes;
-      badgeChanged = this.recomputeVisibleMessageCount(sessionId);
+      badgeChanged = this.applyBadgeUpdate(sessionId, planBadgeRecompute());
       for (const { sdk_uuid } of rows) {
         if (sdk_uuid) this.clearDeliveryTurnEnd(sessionId, sdk_uuid);
       }
@@ -1278,7 +1294,7 @@ export class SDKMessageRepository {
     let badgeChanged = false;
     this.db.transaction(() => {
       deleted = stmt.run(sessionId, isoTimestamp).changes;
-      badgeChanged = this.recomputeVisibleMessageCount(sessionId);
+      badgeChanged = this.applyBadgeUpdate(sessionId, planBadgeRecompute());
       for (const { sdk_uuid } of rows) {
         if (sdk_uuid) this.clearDeliveryTurnEnd(sessionId, sdk_uuid);
       }
@@ -1800,6 +1816,7 @@ export class SDKMessageRepository {
       variant: 'hyperneo_action',
       sendStatus: null,
     });
+    const badgeUpdate = planAdmissionBadgeUpdate(admission);
     const taskId = this.resolveTaskIdForSession(sessionId);
     const conversationTurnIndex = this.resolveConversationTurnIndex(
       taskId,
@@ -1826,9 +1843,9 @@ export class SDKMessageRepository {
 
     this.db.transaction(() => {
       insertStmt.run(...values, conversationTurnIndex, admission.sdkUuid);
-      if (admission.countsTowardsBadge) this.bumpVisibleMessageCount(sessionId, 1);
+      this.applyBadgeUpdate(sessionId, badgeUpdate);
     })();
-    if (admission.countsTowardsBadge) this.notifySessionsChanged(sessionId);
+    if (badgeUpdate.kind === 'delta') this.notifySessionsChanged(sessionId);
     this.scheduleMessageSearchIndex(id);
     return id;
   }

--- a/packages/daemon/tests/unit/4-space-storage/storage/sdk-message-badge.test.ts
+++ b/packages/daemon/tests/unit/4-space-storage/storage/sdk-message-badge.test.ts
@@ -1,0 +1,193 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
+import type { HyperNeoActionMessage } from '@hyperneo/shared';
+import type { SDKMessage } from '@hyperneo/shared/sdk';
+import {
+  planAdmissionBadgeUpdate,
+  planBadgeRecompute,
+} from '../../../../src/storage/repositories/sdk-message-badge';
+import { SDKMessageRepository } from '../../../../src/storage/repositories/sdk-message-repository';
+import { Database as BunDatabase } from '../../../../src/storage/sqlite-compat';
+import { createReactiveDatabase } from '../../../../src/storage/reactive-database';
+import type { ReactiveDatabase, TableChangeScope } from '../../../../src/storage/reactive-database';
+import { createSpaceTables } from '../../helpers/space-test-db';
+
+const NOW = '2026-01-01T00:00:00.000Z';
+const SID = 'sess-badge-b3';
+
+function userMessage(uuid: string): SDKMessage {
+  return {
+    type: 'user',
+    uuid,
+    message: { role: 'user', content: [{ type: 'text', text: `text-${uuid}` }] },
+  } as unknown as SDKMessage;
+}
+
+function assistantMessage(uuid: string): SDKMessage {
+  return {
+    type: 'assistant',
+    uuid,
+    message: { role: 'assistant', content: [{ type: 'text', text: `text-${uuid}` }] },
+  } as unknown as SDKMessage;
+}
+
+function hiddenSubtypeMessage(subtype: string, uuid: string): SDKMessage {
+  return { type: 'system', subtype, uuid } as unknown as SDKMessage;
+}
+
+function actionMessage(uuid: string): HyperNeoActionMessage {
+  return {
+    type: 'hyperneo_action',
+    uuid,
+    session_id: SID,
+    action: 'sdk_resume_choice',
+    resolved: false,
+    timestamp: Date.parse('2026-02-03T04:05:06.000Z'),
+  };
+}
+
+describe('badge instruction planning (chain B3)', () => {
+  test('an admission record that counts toward the badge plans a delta of +1', () => {
+    expect(planAdmissionBadgeUpdate({ countsTowardsBadge: true })).toEqual({
+      kind: 'delta',
+      delta: 1,
+    });
+  });
+
+  test('an admission record that does not count plans no update', () => {
+    expect(planAdmissionBadgeUpdate({ countsTowardsBadge: false })).toEqual({ kind: 'none' });
+  });
+
+  test('recount sites plan the authoritative recompute instruction', () => {
+    expect(planBadgeRecompute()).toEqual({ kind: 'recompute' });
+  });
+});
+
+describe('badge instruction interpretation (chain B3)', () => {
+  let db: BunDatabase;
+  let repo: SDKMessageRepository;
+  let notifySpy: ReturnType<typeof mock<(table: string, scope?: TableChangeScope) => void>>;
+
+  beforeEach(() => {
+    db = new BunDatabase(':memory:');
+    createSpaceTables(db);
+    db.prepare(
+      `INSERT INTO sessions
+         (id, title, created_at, last_active_at, status, config, metadata, type)
+       VALUES (?, ?, ?, ?, 'active', '{}', '{}', 'worker')`
+    ).run(SID, SID, NOW, NOW);
+    const reactiveDb: ReactiveDatabase = createReactiveDatabase({
+      getDatabase: () => db,
+    } as never);
+    notifySpy = mock((_table: string, _scope?: TableChangeScope) => {});
+    reactiveDb.notifyChange = notifySpy;
+    repo = new SDKMessageRepository(db, reactiveDb);
+  });
+
+  afterEach(() => {
+    db.close();
+  });
+
+  function badgeOf(sessionId: string = SID): number {
+    return (
+      db.prepare(`SELECT visible_message_count AS n FROM sessions WHERE id = ?`).get(sessionId) as {
+        n: number;
+      }
+    ).n;
+  }
+
+  function sessionsNotified(): Array<string | undefined> {
+    const calls = notifySpy.mock.calls as Array<[string, TableChangeScope | undefined]>;
+    return calls.filter((call) => call[0] === 'sessions').map((call) => call[1]?.sessionId);
+  }
+
+  test('save sites notify sessions exactly when the planned instruction is a delta', () => {
+    expect(repo.saveSDKMessage(SID, assistantMessage('a-1'))).toBe(true);
+    expect(sessionsNotified()).toEqual([SID]);
+    notifySpy.mockClear();
+
+    expect(repo.saveSDKMessage(SID, hiddenSubtypeMessage('thinking_tokens', 'hidden-1'))).toBe(
+      true
+    );
+    expect(sessionsNotified()).toEqual([]);
+    notifySpy.mockClear();
+
+    repo.saveUserMessage(SID, userMessage('u-deferred'), 'deferred');
+    expect(sessionsNotified()).toEqual([]);
+    notifySpy.mockClear();
+
+    repo.saveUserMessage(SID, userMessage('u-consumed'), 'consumed');
+    expect(sessionsNotified()).toEqual([SID]);
+    notifySpy.mockClear();
+
+    repo.saveHyperNeoActionMessage(SID, actionMessage('act-1'));
+    expect(sessionsNotified()).toEqual([SID]);
+    expect(badgeOf()).toBe(3);
+  });
+
+  test('the status flip notifies a session only when the authoritative count changes', () => {
+    const id = repo.saveUserMessageCore(SID, userMessage('u-flip'), 'enqueued').id;
+    expect(badgeOf()).toBe(0);
+
+    repo.updateMessageStatus([id], 'consumed');
+    expect(badgeOf()).toBe(1);
+    expect(sessionsNotified()).toEqual([SID]);
+    notifySpy.mockClear();
+
+    repo.updateMessageStatus([id], 'enqueued');
+    expect(badgeOf()).toBe(0);
+    expect(sessionsNotified()).toEqual([SID]);
+    notifySpy.mockClear();
+
+    repo.updateMessageStatus([id], 'deferred');
+    expect(badgeOf()).toBe(0);
+    expect(sessionsNotified()).toEqual([]);
+  });
+
+  test('rewind operators notify only when the recount changes the stored count', () => {
+    repo.saveSDKMessage(SID, assistantMessage('r-1'));
+    repo.saveSDKMessage(SID, assistantMessage('r-2'));
+    expect(badgeOf()).toBe(2);
+    notifySpy.mockClear();
+
+    expect(repo.deleteMessagesAfter(SID, Date.now() + 60_000)).toBe(0);
+    expect(badgeOf()).toBe(2);
+    expect(sessionsNotified()).toEqual([]);
+    notifySpy.mockClear();
+
+    const earliest = (
+      db.prepare(`SELECT MIN(timestamp) AS t FROM sdk_messages WHERE session_id = ?`).get(SID) as {
+        t: string;
+      }
+    ).t;
+    expect(repo.deleteMessagesAtAndAfter(SID, Date.parse(earliest))).toBeGreaterThan(0);
+    expect(badgeOf()).toBe(0);
+    expect(sessionsNotified()).toEqual([SID]);
+  });
+
+  test('deletePendingUserMessage recounts the badge without notifying sessions', () => {
+    const id = repo.saveUserMessageCore(SID, userMessage('u-pending'), 'deferred').id;
+    db.prepare(`UPDATE sessions SET visible_message_count = 7 WHERE id = ?`).run(SID);
+    notifySpy.mockClear();
+
+    const removed = repo.deletePendingUserMessage(SID, id, 'deferred');
+
+    expect(removed?.dbId).toBe(id);
+    expect(badgeOf()).toBe(0);
+    expect(notifySpy).not.toHaveBeenCalled();
+  });
+
+  test('recomputeVisibleMessageCount repairs drift without notifying (script contract)', () => {
+    db.prepare(
+      `INSERT INTO sdk_messages
+         (id, session_id, message_type, message_subtype, sdk_message, timestamp, send_status, parent_tool_use_id)
+       VALUES (?, ?, 'assistant', NULL, '{}', ?, 'consumed', NULL)`
+    ).run('raw-bypass', SID, NOW);
+    expect(badgeOf()).toBe(0);
+    notifySpy.mockClear();
+
+    expect(repo.recomputeVisibleMessageCount(SID)).toBe(true);
+    expect(badgeOf()).toBe(1);
+    expect(repo.recomputeVisibleMessageCount(SID)).toBe(false);
+    expect(notifySpy).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Unifies visible_message_count maintenance as a pure instruction set in `sdk-message-badge.ts`: saves (`saveSDKMessage`, `saveUserMessageCore`, `saveHyperNeoActionMessage`) plan a `delta(+1)` over the admission record, while the status flip, both rewind operators, and `deletePendingUserMessage` plan an authoritative `recompute` (COUNT(*) + conditional update, which also repairs pre-existing drift — delta subtraction ruled out as a behavior change). The repository keeps one `applyBadgeUpdate` interpreter; `recomputeVisibleMessageCount` stays public and notification-free for the recover-messages script. New suite pins the planners plus the notification nuances, including `deletePendingUserMessage` staying notify-free; B1 drift pins and the badge COUNT-oracle suite guard parity.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/lsm/hyperneo/pull/2794" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->